### PR TITLE
setup-python

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -61,7 +61,7 @@ jobs:
         # Used to specify a package manager for caching in the default directory. Supported values: pip, pipenv, poetry.
         cache: pipenv # optional
         cache-dependency-path: |
-          Pipfile.lock
+          does-not-exist/Pipfile.lock
         # Set this option if you want the action to check for the latest available version that satisfies the version spec.
         check-latest: true # optional
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -61,7 +61,7 @@ jobs:
         # Used to specify a package manager for caching in the default directory. Supported values: pip, pipenv, poetry.
         cache: pipenv # optional
         cache-dependency-path: |
-          does-not-exist/Pipfile.lock
+          Pipfile.lock
         # Set this option if you want the action to check for the latest available version that satisfies the version spec.
         check-latest: true # optional
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,7 +53,7 @@ jobs:
         # queries: security-extended,security-and-quality
         queries: security-extended
         
-    - name: Setup Python
+    - name: Setup Python Step
       uses: actions/setup-python@v4.2.0
       with:
         # Version range or exact version of Python or PyPy to use, using SemVer's version range syntax. Reads from .python-version if unset.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,6 +52,18 @@ jobs:
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
         queries: security-extended
+        
+    - name: Setup Python
+      uses: actions/setup-python@v4.2.0
+      with:
+        # Version range or exact version of Python or PyPy to use, using SemVer's version range syntax. Reads from .python-version if unset.
+        python-version: '3.7' # optional
+        # Used to specify a package manager for caching in the default directory. Supported values: pip, pipenv, poetry.
+        cache: pipenv # optional
+        cache-dependency-path: |
+          Pipfile.lock
+        # Set this option if you want the action to check for the latest available version that satisfies the version spec.
+        check-latest: true # optional
 
         
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).


### PR DESCRIPTION
Try to repro issue: https://github.com/actions/setup-python/issues/436

Only [failure](https://github.com/octodemo/felickz-advanced-security-python/actions/runs/3063783004) i can invoke is a bogus setup for cache-dependency-path: 
>No file in /home/runner/work/felickz-advanced-security-python/felickz-advanced-security-python matched to [does-not-exist/Pipfile.lock], make sure you have checked out the target repository