### PR TITLE
CWE-798 - Hardcoded Credential Test

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -8,11 +8,12 @@ queries:
 languages:
 
 paths:
-  - src/main/
-  - python/
+  - .
 
 paths-ignore:
   - src/test/
+  - images/
+  - templates/
   - '**/node_modules/'
 
 build: |

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,18 @@
+name: "CodeQL config"
+
+disable-default-queries: false
+
+queries:
+  - uses: security-and-quality
+
+languages:
+
+paths:
+  - src/main/
+  - python/
+
+paths-ignore:
+  - src/test/
+  - '**/node_modules/'
+
+build: |

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -5,7 +5,7 @@ disable-default-queries: false
 queries:
   - uses: security-and-quality
 
-languages: java, python
+languages: java,python
 
 paths:
   - .

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,10 +3,12 @@ name: "CodeQL config"
 disable-default-queries: false
 
 queries:
-  - uses: java-security-and-quality
-  - uses: python-security-and-quality
+  - uses: code-scanning
+  #Doesnt work in actions env: Error: The configuration file "codeql-config.yml" is invalid: property "queries.uses" must be a built-in suite (security-extended or security-and-quality), a relative path, or be of the form "owner/repo[/path]@ref"
+  #- uses: java-security-and-quality
+  #- uses: python-security-and-quality
 
-languagesasdf: java,python
+#this has no impact... languages: java,python
 
 paths:
   - .

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,9 +3,10 @@ name: "CodeQL config"
 disable-default-queries: false
 
 queries:
-  - uses: security-and-quality
+  - uses: java-security-and-quality
+  - uses: python-security-and-quality
 
-languages: java,python
+languagesasdf: java,python
 
 paths:
   - .

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -5,7 +5,7 @@ disable-default-queries: false
 queries:
   - uses: security-and-quality
 
-languages:
+languages: java, python
 
 paths:
   - .

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,12 +46,13 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
+        config: ./.github/codeql/codeql-config.yml
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
-        queries: security-extended
+        #queries: security-extended
 
         
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'python' ]
+        language: [ 'python', 'java' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,6 +44,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
+        tools: https://github.com/github/codeql-action/releases/download/codeql-bundle-20211115/codeql-bundle-linux64.tar.gz
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
         config-file: ./.github/codeql/codeql-config.yml

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,7 +46,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
-        config: ./.github/codeql/codeql-config.yml
+        config-file: ./.github/codeql/codeql-config.yml
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# CodeQL
+pythondb/

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,7 @@ dmypy.json
 
 # CodeQL
 pythondb/
+codeql_databases/
+
+#MacOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Output
 Compiling query plan for /opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/python-queries/0.1.3/Security/CWE-798/HardcodedCredentials.ql.
 [157/166] Found in cache: /opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/python-queries/0.1.3/Security/CWE-798/HardcodedCredentials.ql.
 HardcodedCredentials.ql                    : [130/166 eval 2.5s] Results written to codeql/python-queries/Security/CWE-798/HardcodedCredentials.bqrs.
+```
 
 ### baseline
 
@@ -252,3 +253,25 @@ export PAT="<grab a token>"
 echo $PAT | codeql github upload-results --repository=octodemo/felickz-advanced-security-python --commit=ed08e82a4a2b99bdefe5c92d6ac916872480d677 --ref=refs/pull/3/head --sarif=./results.sarif --github-auth-stdin
 ```
 
+# DB Cluster CLI Commands
+
+Installed openjdk17(`brew install openjdk@17`), maven(`brew install --ignore-dependencies maven`), Added a java project
+```
+mvn archetype:generate -DgroupId=com.mycompany.app -DartifactId=my-app -DarchetypeArtifactId=maven-archetype-quickstart -DarchetypeVersion=1.4 -DinteractiveMode=false
+```
+
+Create CodeQL DB for multi lang cluster
+
+```
+codeql database create codeql_databases --db-cluster --language=java,python --command='mvn clean install'  --codescanning-config='./.github/codeql/codeql-config.yml' --no-run-unnecessary-builds --overwrite
+```
+
+run scan for each:
+
+```
+codeql database analyze codeql_databases/python --format=sarif-latest --sarif-category=".github/workflows/codeql-analysis.yml:analyze/language:python" --output=./python-results.sarif
+```
+
+```
+codeql database analyze codeql_databases/java --format=sarif-latest --sarif-category=".github/workflows/codeql-analysis.yml:analyze/language:java" --output=./java-results.sarif
+```

--- a/README.md
+++ b/README.md
@@ -207,3 +207,48 @@ Check out [GitHub's Security feature page](https://github.com/features/security)
 
 Check out the Code Scanning [documentation](https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/about-code-scanning) for additional configuration options and technical details.
 
+## CLI Commands
+### database create
+```
+codeql database create pythondb --language=python --codescanning-config='./.github/codeql/codeql-config.yml' --overwrite
+```
+
+Output
+   - is extracting file we expect
+```
+[2022-09-16 10:05:43] [build-stdout] [INFO] [2] Extracted file /Users/felickz/Repos/felickz-advanced-security-python/server/webapp.py in 25ms
+```
+
+### database analyze
+>If no queries are specified, the CLI will automatically determine a suitable set of queries to run. In particular, if a Code Scanning configuation file was specfied at database creation time using --codescanning-config then the queries from this will be used. Otherwise, the default queries for the langauge being analyzed will be used.
+
+```
+codeql database analyze ./pythondb --format=sarif-latest --sarif-category=".github/workflows/codeql-analysis.yml:analyze/language:python" --output=./results.sarif
+```
+
+Output
+- is running our expected security-extended queries (HardcodedCredentials.ql)
+
+```
+[156/166] Found in cache: /opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/python-queries/0.1.3/Security/CWE-732/WeakFilePermissions.ql.
+Compiling query plan for /opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/python-queries/0.1.3/Security/CWE-798/HardcodedCredentials.ql.
+[157/166] Found in cache: /opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/python-queries/0.1.3/Security/CWE-798/HardcodedCredentials.ql.
+HardcodedCredentials.ql                    : [130/166 eval 2.5s] Results written to codeql/python-queries/Security/CWE-798/HardcodedCredentials.bqrs.
+
+### baseline
+
+```
+codeql database print-baseline ./pythondb
+```
+
+Output:
+>Counted a baseline of 78 lines of code for python.
+
+### github upload-results
+
+```
+export PAT="<grab a token>"
+
+echo $PAT | codeql github upload-results --repository=octodemo/felickz-advanced-security-python --commit=ed08e82a4a2b99bdefe5c92d6ac916872480d677 --ref=refs/pull/3/head --sarif=./results.sarif --github-auth-stdin
+```
+

--- a/java-results.sarif
+++ b/java-results.sarif
@@ -1,0 +1,1662 @@
+{
+  "$schema" : "https://json.schemastore.org/sarif-2.1.0.json",
+  "version" : "2.1.0",
+  "runs" : [ {
+    "tool" : {
+      "driver" : {
+        "name" : "CodeQL",
+        "organization" : "GitHub",
+        "semanticVersion" : "2.9.3",
+        "notifications" : [ {
+          "id" : "java/diagnostics/extraction-errors",
+          "name" : "java/diagnostics/extraction-errors",
+          "shortDescription" : {
+            "text" : "Extraction errors"
+          },
+          "fullDescription" : {
+            "text" : "A list of extraction errors for files in the source code directory."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true
+          },
+          "properties" : {
+            "description" : "A list of extraction errors for files in the source code directory.",
+            "id" : "java/diagnostics/extraction-errors",
+            "kind" : "diagnostic",
+            "name" : "Extraction errors"
+          }
+        }, {
+          "id" : "java/diagnostics/extraction-warnings",
+          "name" : "java/diagnostics/extraction-warnings",
+          "shortDescription" : {
+            "text" : "Extraction warnings"
+          },
+          "fullDescription" : {
+            "text" : "A list of extraction warnings for files in the source code directory."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true
+          },
+          "properties" : {
+            "description" : "A list of extraction warnings for files in the source code directory.",
+            "id" : "java/diagnostics/extraction-warnings",
+            "kind" : "diagnostic",
+            "name" : "Extraction warnings"
+          }
+        }, {
+          "id" : "java/diagnostics/successfully-extracted-files",
+          "name" : "java/diagnostics/successfully-extracted-files",
+          "shortDescription" : {
+            "text" : "Successfully extracted files"
+          },
+          "fullDescription" : {
+            "text" : "A list of all files in the source code directory that were extracted without encountering an error in the file."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true
+          },
+          "properties" : {
+            "description" : "A list of all files in the source code directory that\n              were extracted without encountering an error in the file.",
+            "id" : "java/diagnostics/successfully-extracted-files",
+            "kind" : "diagnostic",
+            "name" : "Successfully extracted files"
+          }
+        } ],
+        "rules" : [ {
+          "id" : "java/implicit-cast-in-compound-assignment",
+          "name" : "java/implicit-cast-in-compound-assignment",
+          "shortDescription" : {
+            "text" : "Implicit narrowing conversion in compound assignment"
+          },
+          "fullDescription" : {
+            "text" : "Compound assignment statements (for example 'intvar += longvar') that implicitly cast a value of a wider type to a narrower type may result in information loss and numeric errors such as overflows."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "security", "external/cwe/cwe-190", "external/cwe/cwe-192", "external/cwe/cwe-197", "external/cwe/cwe-681" ],
+            "description" : "Compound assignment statements (for example 'intvar += longvar') that implicitly\n              cast a value of a wider type to a narrower type may result in information loss and\n              numeric errors such as overflows.",
+            "id" : "java/implicit-cast-in-compound-assignment",
+            "kind" : "problem",
+            "name" : "Implicit narrowing conversion in compound assignment",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "security-severity" : "8.1"
+          }
+        }, {
+          "id" : "java/path-injection",
+          "name" : "java/path-injection",
+          "shortDescription" : {
+            "text" : "Uncontrolled data used in path expression"
+          },
+          "fullDescription" : {
+            "text" : "Accessing paths influenced by users can allow an attacker to access unexpected resources."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-022", "external/cwe/cwe-023", "external/cwe/cwe-036", "external/cwe/cwe-073" ],
+            "description" : "Accessing paths influenced by users can allow an attacker to access unexpected resources.",
+            "id" : "java/path-injection",
+            "kind" : "path-problem",
+            "name" : "Uncontrolled data used in path expression",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "7.5"
+          }
+        }, {
+          "id" : "java/zipslip",
+          "name" : "java/zipslip",
+          "shortDescription" : {
+            "text" : "Arbitrary file write during archive extraction (\"Zip Slip\")"
+          },
+          "fullDescription" : {
+            "text" : "Extracting files from a malicious archive without validating that the destination file path is within the destination directory can cause files outside the destination directory to be overwritten."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-022" ],
+            "description" : "Extracting files from a malicious archive without validating that the\n              destination file path is within the destination directory can cause files outside\n              the destination directory to be overwritten.",
+            "id" : "java/zipslip",
+            "kind" : "path-problem",
+            "name" : "Arbitrary file write during archive extraction (\"Zip Slip\")",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "7.5"
+          }
+        }, {
+          "id" : "java/jndi-injection",
+          "name" : "java/jndi-injection",
+          "shortDescription" : {
+            "text" : "JNDI lookup with user-controlled name"
+          },
+          "fullDescription" : {
+            "text" : "Performing a JNDI lookup with a user-controlled name can lead to the download of an untrusted object and to execution of arbitrary code."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-074" ],
+            "description" : "Performing a JNDI lookup with a user-controlled name can lead to the download of an untrusted\n              object and to execution of arbitrary code.",
+            "id" : "java/jndi-injection",
+            "kind" : "path-problem",
+            "name" : "JNDI lookup with user-controlled name",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.8"
+          }
+        }, {
+          "id" : "java/xslt-injection",
+          "name" : "java/xslt-injection",
+          "shortDescription" : {
+            "text" : "XSLT transformation with user-controlled stylesheet"
+          },
+          "fullDescription" : {
+            "text" : "Performing an XSLT transformation with user-controlled stylesheets can lead to information disclosure or execution of arbitrary code."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-074" ],
+            "description" : "Performing an XSLT transformation with user-controlled stylesheets can lead to\n              information disclosure or execution of arbitrary code.",
+            "id" : "java/xslt-injection",
+            "kind" : "path-problem",
+            "name" : "XSLT transformation with user-controlled stylesheet",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.8"
+          }
+        }, {
+          "id" : "java/command-line-injection",
+          "name" : "java/command-line-injection",
+          "shortDescription" : {
+            "text" : "Uncontrolled command line"
+          },
+          "fullDescription" : {
+            "text" : "Using externally controlled strings in a command line is vulnerable to malicious changes in the strings."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-078", "external/cwe/cwe-088" ],
+            "description" : "Using externally controlled strings in a command line is vulnerable to malicious\n              changes in the strings.",
+            "id" : "java/command-line-injection",
+            "kind" : "path-problem",
+            "name" : "Uncontrolled command line",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.8"
+          }
+        }, {
+          "id" : "java/concatenated-command-line",
+          "name" : "java/concatenated-command-line",
+          "shortDescription" : {
+            "text" : "Building a command line with string concatenation"
+          },
+          "fullDescription" : {
+            "text" : "Using concatenated strings in a command line is vulnerable to malicious insertion of special characters in the strings."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-078", "external/cwe/cwe-088" ],
+            "description" : "Using concatenated strings in a command line is vulnerable to malicious\n              insertion of special characters in the strings.",
+            "id" : "java/concatenated-command-line",
+            "kind" : "problem",
+            "name" : "Building a command line with string concatenation",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.8"
+          }
+        }, {
+          "id" : "java/xss",
+          "name" : "java/xss",
+          "shortDescription" : {
+            "text" : "Cross-site scripting"
+          },
+          "fullDescription" : {
+            "text" : "Writing user input directly to a web page allows for a cross-site scripting vulnerability."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-079" ],
+            "description" : "Writing user input directly to a web page\n              allows for a cross-site scripting vulnerability.",
+            "id" : "java/xss",
+            "kind" : "path-problem",
+            "name" : "Cross-site scripting",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "6.1"
+          }
+        }, {
+          "id" : "java/sql-injection",
+          "name" : "java/sql-injection",
+          "shortDescription" : {
+            "text" : "Query built from user-controlled sources"
+          },
+          "fullDescription" : {
+            "text" : "Building a SQL or Java Persistence query from user-controlled sources is vulnerable to insertion of malicious code by the user."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-089", "external/cwe/cwe-564" ],
+            "description" : "Building a SQL or Java Persistence query from user-controlled sources is vulnerable to insertion of\n              malicious code by the user.",
+            "id" : "java/sql-injection",
+            "kind" : "path-problem",
+            "name" : "Query built from user-controlled sources",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "8.8"
+          }
+        }, {
+          "id" : "java/ldap-injection",
+          "name" : "java/ldap-injection",
+          "shortDescription" : {
+            "text" : "LDAP query built from user-controlled sources"
+          },
+          "fullDescription" : {
+            "text" : "Building an LDAP query from user-controlled sources is vulnerable to insertion of malicious LDAP code by the user."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-090" ],
+            "description" : "Building an LDAP query from user-controlled sources is vulnerable to insertion of\n              malicious LDAP code by the user.",
+            "id" : "java/ldap-injection",
+            "kind" : "path-problem",
+            "name" : "LDAP query built from user-controlled sources",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.8"
+          }
+        }, {
+          "id" : "java/groovy-injection",
+          "name" : "java/groovy-injection",
+          "shortDescription" : {
+            "text" : "Groovy Language injection"
+          },
+          "fullDescription" : {
+            "text" : "Evaluation of a user-controlled Groovy script may lead to arbitrary code execution."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-094" ],
+            "description" : "Evaluation of a user-controlled Groovy script\n              may lead to arbitrary code execution.",
+            "id" : "java/groovy-injection",
+            "kind" : "path-problem",
+            "name" : "Groovy Language injection",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.3"
+          }
+        }, {
+          "id" : "java/insecure-bean-validation",
+          "name" : "java/insecure-bean-validation",
+          "shortDescription" : {
+            "text" : "Insecure Bean Validation"
+          },
+          "fullDescription" : {
+            "text" : "User-controlled data may be evaluated as a Java EL expression, leading to arbitrary code execution."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-094" ],
+            "description" : "User-controlled data may be evaluated as a Java EL expression, leading to arbitrary code execution.",
+            "id" : "java/insecure-bean-validation",
+            "kind" : "path-problem",
+            "name" : "Insecure Bean Validation",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.3"
+          }
+        }, {
+          "id" : "java/jexl-expression-injection",
+          "name" : "java/jexl-expression-injection",
+          "shortDescription" : {
+            "text" : "Expression language injection (JEXL)"
+          },
+          "fullDescription" : {
+            "text" : "Evaluation of a user-controlled JEXL expression may lead to arbitrary code execution."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-094" ],
+            "description" : "Evaluation of a user-controlled JEXL expression\n              may lead to arbitrary code execution.",
+            "id" : "java/jexl-expression-injection",
+            "kind" : "path-problem",
+            "name" : "Expression language injection (JEXL)",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.3"
+          }
+        }, {
+          "id" : "java/mvel-expression-injection",
+          "name" : "java/mvel-expression-injection",
+          "shortDescription" : {
+            "text" : "Expression language injection (MVEL)"
+          },
+          "fullDescription" : {
+            "text" : "Evaluation of a user-controlled MVEL expression may lead to remote code execution."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-094" ],
+            "description" : "Evaluation of a user-controlled MVEL expression\n              may lead to remote code execution.",
+            "id" : "java/mvel-expression-injection",
+            "kind" : "path-problem",
+            "name" : "Expression language injection (MVEL)",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.3"
+          }
+        }, {
+          "id" : "java/spel-expression-injection",
+          "name" : "java/spel-expression-injection",
+          "shortDescription" : {
+            "text" : "Expression language injection (Spring)"
+          },
+          "fullDescription" : {
+            "text" : "Evaluation of a user-controlled Spring Expression Language (SpEL) expression may lead to remote code execution."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-094" ],
+            "description" : "Evaluation of a user-controlled Spring Expression Language (SpEL) expression\n              may lead to remote code execution.",
+            "id" : "java/spel-expression-injection",
+            "kind" : "path-problem",
+            "name" : "Expression language injection (Spring)",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.3"
+          }
+        }, {
+          "id" : "java/maven/dependency-upon-bintray",
+          "name" : "java/maven/dependency-upon-bintray",
+          "shortDescription" : {
+            "text" : "Depending upon JCenter/Bintray as an artifact repository"
+          },
+          "fullDescription" : {
+            "text" : "Using a deprecated artifact repository may eventually give attackers access for a supply chain attack."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-1104" ],
+            "description" : "Using a deprecated artifact repository may eventually give attackers access for a supply chain attack.",
+            "id" : "java/maven/dependency-upon-bintray",
+            "kind" : "problem",
+            "name" : "Depending upon JCenter/Bintray as an artifact repository",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "security-severity" : "6.5"
+          }
+        }, {
+          "id" : "java/netty-http-request-or-response-splitting",
+          "name" : "java/netty-http-request-or-response-splitting",
+          "shortDescription" : {
+            "text" : "Disabled Netty HTTP header validation"
+          },
+          "fullDescription" : {
+            "text" : "Disabling HTTP header validation makes code vulnerable to attack by header splitting if user input is written directly to an HTTP header."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-93", "external/cwe/cwe-113" ],
+            "description" : "Disabling HTTP header validation makes code vulnerable to\n              attack by header splitting if user input is written directly to\n              an HTTP header.",
+            "id" : "java/netty-http-request-or-response-splitting",
+            "kind" : "problem",
+            "name" : "Disabled Netty HTTP header validation",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "6.1"
+          }
+        }, {
+          "id" : "java/http-response-splitting",
+          "name" : "java/http-response-splitting",
+          "shortDescription" : {
+            "text" : "HTTP response splitting"
+          },
+          "fullDescription" : {
+            "text" : "Writing user input directly to an HTTP header makes code vulnerable to attack by header splitting."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-113" ],
+            "description" : "Writing user input directly to an HTTP header\n              makes code vulnerable to attack by header splitting.",
+            "id" : "java/http-response-splitting",
+            "kind" : "path-problem",
+            "name" : "HTTP response splitting",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "6.1"
+          }
+        }, {
+          "id" : "java/tainted-format-string",
+          "name" : "java/tainted-format-string",
+          "shortDescription" : {
+            "text" : "Use of externally-controlled format string"
+          },
+          "fullDescription" : {
+            "text" : "Using external input in format strings can lead to exceptions or information leaks."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-134" ],
+            "description" : "Using external input in format strings can lead to exceptions or information leaks.",
+            "id" : "java/tainted-format-string",
+            "kind" : "path-problem",
+            "name" : "Use of externally-controlled format string",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.3"
+          }
+        }, {
+          "id" : "java/stack-trace-exposure",
+          "name" : "java/stack-trace-exposure",
+          "shortDescription" : {
+            "text" : "Information exposure through a stack trace"
+          },
+          "fullDescription" : {
+            "text" : "Information from a stack trace propagates to an external user. Stack traces can unintentionally reveal implementation details that are useful to an attacker for developing a subsequent exploit."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-209", "external/cwe/cwe-497" ],
+            "description" : "Information from a stack trace propagates to an external user.\n              Stack traces can unintentionally reveal implementation details\n              that are useful to an attacker for developing a subsequent exploit.",
+            "id" : "java/stack-trace-exposure",
+            "kind" : "problem",
+            "name" : "Information exposure through a stack trace",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "5.4"
+          }
+        }, {
+          "id" : "java/android/intent-uri-permission-manipulation",
+          "name" : "java/android/intent-uri-permission-manipulation",
+          "shortDescription" : {
+            "text" : "Intent URI permission manipulation"
+          },
+          "fullDescription" : {
+            "text" : "Returning an externally provided Intent via 'setResult' may allow a malicious application to access arbitrary content providers of the vulnerable application."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-266", "external/cwe/cwe-926" ],
+            "description" : "Returning an externally provided Intent via 'setResult' may allow a malicious\n              application to access arbitrary content providers of the vulnerable application.",
+            "id" : "java/android/intent-uri-permission-manipulation",
+            "kind" : "path-problem",
+            "name" : "Intent URI permission manipulation",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "7.8"
+          }
+        }, {
+          "id" : "java/insecure-trustmanager",
+          "name" : "java/insecure-trustmanager",
+          "shortDescription" : {
+            "text" : "`TrustManager` that accepts all certificates"
+          },
+          "fullDescription" : {
+            "text" : "Trusting all certificates allows an attacker to perform a machine-in-the-middle attack."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-295" ],
+            "description" : "Trusting all certificates allows an attacker to perform a machine-in-the-middle attack.",
+            "id" : "java/insecure-trustmanager",
+            "kind" : "path-problem",
+            "name" : "`TrustManager` that accepts all certificates",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "7.5"
+          }
+        }, {
+          "id" : "java/unsafe-hostname-verification",
+          "name" : "java/unsafe-hostname-verification",
+          "shortDescription" : {
+            "text" : "Unsafe hostname verification"
+          },
+          "fullDescription" : {
+            "text" : "Marking a certificate as valid for a host without checking the certificate hostname allows an attacker to perform a machine-in-the-middle attack."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-297" ],
+            "description" : "Marking a certificate as valid for a host without checking the certificate hostname allows an attacker to perform a machine-in-the-middle attack.",
+            "id" : "java/unsafe-hostname-verification",
+            "kind" : "path-problem",
+            "name" : "Unsafe hostname verification",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "5.9"
+          }
+        }, {
+          "id" : "java/cleartext-storage-in-cookie",
+          "name" : "java/cleartext-storage-in-cookie",
+          "shortDescription" : {
+            "text" : "Cleartext storage of sensitive information in cookie"
+          },
+          "fullDescription" : {
+            "text" : "Storing sensitive information in cleartext can expose it to an attacker."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-315" ],
+            "description" : "Storing sensitive information in cleartext can expose it to an attacker.",
+            "id" : "java/cleartext-storage-in-cookie",
+            "kind" : "problem",
+            "name" : "Cleartext storage of sensitive information in cookie",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "5.0"
+          }
+        }, {
+          "id" : "java/weak-cryptographic-algorithm",
+          "name" : "java/weak-cryptographic-algorithm",
+          "shortDescription" : {
+            "text" : "Use of a broken or risky cryptographic algorithm"
+          },
+          "fullDescription" : {
+            "text" : "Using broken or weak cryptographic algorithms can allow an attacker to compromise security."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-327", "external/cwe/cwe-328" ],
+            "description" : "Using broken or weak cryptographic algorithms can allow an attacker to compromise security.",
+            "id" : "java/weak-cryptographic-algorithm",
+            "kind" : "path-problem",
+            "name" : "Use of a broken or risky cryptographic algorithm",
+            "precision" : "high",
+            "problem.severity" : "warning",
+            "security-severity" : "7.5"
+          }
+        }, {
+          "id" : "java/predictable-seed",
+          "name" : "java/predictable-seed",
+          "shortDescription" : {
+            "text" : "Use of a predictable seed in a secure random number generator"
+          },
+          "fullDescription" : {
+            "text" : "Using a predictable seed in a pseudo-random number generator can lead to predictability of the numbers generated by it."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-335", "external/cwe/cwe-337" ],
+            "description" : "Using a predictable seed in a pseudo-random number generator can lead to predictability of the numbers generated by it.",
+            "id" : "java/predictable-seed",
+            "kind" : "problem",
+            "name" : "Use of a predictable seed in a secure random number generator",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.8"
+          }
+        }, {
+          "id" : "java/jhipster-prng",
+          "name" : "java/jhipster-prng",
+          "shortDescription" : {
+            "text" : "Detect JHipster Generator Vulnerability CVE-2019-16303"
+          },
+          "fullDescription" : {
+            "text" : "Using a vulnerable version of JHipster to generate random numbers makes it easier for attackers to take over accounts."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-338" ],
+            "description" : "Using a vulnerable version of JHipster to generate random numbers makes it easier for attackers to take over accounts.",
+            "id" : "java/jhipster-prng",
+            "kind" : "problem",
+            "name" : "Detect JHipster Generator Vulnerability CVE-2019-16303",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "security-severity" : "7.8"
+          }
+        }, {
+          "id" : "java/missing-jwt-signature-check",
+          "name" : "java/missing-jwt-signature-check",
+          "shortDescription" : {
+            "text" : "Missing JWT signature check"
+          },
+          "fullDescription" : {
+            "text" : "Failing to check the Json Web Token (JWT) signature may allow an attacker to forge their own tokens."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-347" ],
+            "description" : "Failing to check the Json Web Token (JWT) signature may allow an attacker to forge their own tokens.",
+            "id" : "java/missing-jwt-signature-check",
+            "kind" : "path-problem",
+            "name" : "Missing JWT signature check",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "7.8"
+          }
+        }, {
+          "id" : "java/spring-disabled-csrf-protection",
+          "name" : "java/spring-disabled-csrf-protection",
+          "shortDescription" : {
+            "text" : "Disabled Spring CSRF protection"
+          },
+          "fullDescription" : {
+            "text" : "Disabling CSRF protection makes the application vulnerable to a Cross-Site Request Forgery (CSRF) attack."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-352" ],
+            "description" : "Disabling CSRF protection makes the application vulnerable to\n              a Cross-Site Request Forgery (CSRF) attack.",
+            "id" : "java/spring-disabled-csrf-protection",
+            "kind" : "problem",
+            "name" : "Disabled Spring CSRF protection",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "8.8"
+          }
+        }, {
+          "id" : "java/android/fragment-injection",
+          "name" : "java/android/fragment-injection",
+          "shortDescription" : {
+            "text" : "Android fragment injection"
+          },
+          "fullDescription" : {
+            "text" : "Instantiating an Android fragment from a user-provided value may allow a malicious application to bypass access controls, exposing the application to unintended effects."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-470" ],
+            "description" : "Instantiating an Android fragment from a user-provided value\n              may allow a malicious application to bypass access controls,  exposing the application to unintended effects.",
+            "id" : "java/android/fragment-injection",
+            "kind" : "path-problem",
+            "name" : "Android fragment injection",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.8"
+          }
+        }, {
+          "id" : "java/android/fragment-injection-preference-activity",
+          "name" : "java/android/fragment-injection-preference-activity",
+          "shortDescription" : {
+            "text" : "Android fragment injection in PreferenceActivity"
+          },
+          "fullDescription" : {
+            "text" : "An insecure implementation of the 'isValidFragment' method of the 'PreferenceActivity' class may allow a malicious application to bypass access controls, exposing the application to unintended effects."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-470" ],
+            "description" : "An insecure implementation of the 'isValidFragment' method\n              of the 'PreferenceActivity' class may allow a malicious application to bypass access controls,\n              exposing the application to unintended effects.",
+            "id" : "java/android/fragment-injection-preference-activity",
+            "kind" : "problem",
+            "name" : "Android fragment injection in PreferenceActivity",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.8"
+          }
+        }, {
+          "id" : "java/unsafe-deserialization",
+          "name" : "java/unsafe-deserialization",
+          "shortDescription" : {
+            "text" : "Deserialization of user-controlled data"
+          },
+          "fullDescription" : {
+            "text" : "Deserializing user-controlled data may allow attackers to execute arbitrary code."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-502" ],
+            "description" : "Deserializing user-controlled data may allow attackers to\n              execute arbitrary code.",
+            "id" : "java/unsafe-deserialization",
+            "kind" : "path-problem",
+            "name" : "Deserialization of user-controlled data",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.8"
+          }
+        }, {
+          "id" : "java/unvalidated-url-redirection",
+          "name" : "java/unvalidated-url-redirection",
+          "shortDescription" : {
+            "text" : "URL redirection from remote source"
+          },
+          "fullDescription" : {
+            "text" : "URL redirection based on unvalidated user-input may cause redirection to malicious web sites."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-601" ],
+            "description" : "URL redirection based on unvalidated user-input\n              may cause redirection to malicious web sites.",
+            "id" : "java/unvalidated-url-redirection",
+            "kind" : "path-problem",
+            "name" : "URL redirection from remote source",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "6.1"
+          }
+        }, {
+          "id" : "java/xxe",
+          "name" : "java/xxe",
+          "shortDescription" : {
+            "text" : "Resolving XML external entity in user-controlled data"
+          },
+          "fullDescription" : {
+            "text" : "Parsing user-controlled XML documents and allowing expansion of external entity references may lead to disclosure of confidential data or denial of service."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-611", "external/cwe/cwe-776", "external/cwe/cwe-827" ],
+            "description" : "Parsing user-controlled XML documents and allowing expansion of external entity\n references may lead to disclosure of confidential data or denial of service.",
+            "id" : "java/xxe",
+            "kind" : "path-problem",
+            "name" : "Resolving XML external entity in user-controlled data",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.1"
+          }
+        }, {
+          "id" : "java/insecure-cookie",
+          "name" : "java/insecure-cookie",
+          "shortDescription" : {
+            "text" : "Failure to use secure cookies"
+          },
+          "fullDescription" : {
+            "text" : "Insecure cookies may be sent in cleartext, which makes them vulnerable to interception."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-614" ],
+            "description" : "Insecure cookies may be sent in cleartext, which makes them vulnerable to\n              interception.",
+            "id" : "java/insecure-cookie",
+            "kind" : "problem",
+            "name" : "Failure to use secure cookies",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "5.0"
+          }
+        }, {
+          "id" : "java/xml/xpath-injection",
+          "name" : "java/xml/xpath-injection",
+          "shortDescription" : {
+            "text" : "XPath injection"
+          },
+          "fullDescription" : {
+            "text" : "Building an XPath expression from user-controlled sources is vulnerable to insertion of malicious code by the user."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-643" ],
+            "description" : "Building an XPath expression from user-controlled sources is vulnerable to insertion of\n              malicious code by the user.",
+            "id" : "java/xml/xpath-injection",
+            "kind" : "path-problem",
+            "name" : "XPath injection",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.8"
+          }
+        }, {
+          "id" : "java/tainted-numeric-cast",
+          "name" : "java/tainted-numeric-cast",
+          "shortDescription" : {
+            "text" : "User-controlled data in numeric cast"
+          },
+          "fullDescription" : {
+            "text" : "Casting user-controlled numeric data to a narrower type without validation can cause unexpected truncation."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-197", "external/cwe/cwe-681" ],
+            "description" : "Casting user-controlled numeric data to a narrower type without validation\n              can cause unexpected truncation.",
+            "id" : "java/tainted-numeric-cast",
+            "kind" : "path-problem",
+            "name" : "User-controlled data in numeric cast",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.0"
+          }
+        }, {
+          "id" : "java/polynomial-redos",
+          "name" : "java/polynomial-redos",
+          "shortDescription" : {
+            "text" : "Polynomial regular expression used on uncontrolled data"
+          },
+          "fullDescription" : {
+            "text" : "A regular expression that can require polynomial time to match may be vulnerable to denial-of-service attacks."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-730", "external/cwe/cwe-400" ],
+            "description" : "A regular expression that can require polynomial time\n              to match may be vulnerable to denial-of-service attacks.",
+            "id" : "java/polynomial-redos",
+            "kind" : "path-problem",
+            "name" : "Polynomial regular expression used on uncontrolled data",
+            "precision" : "high",
+            "problem.severity" : "warning",
+            "security-severity" : "7.5"
+          }
+        }, {
+          "id" : "java/redos",
+          "name" : "java/redos",
+          "shortDescription" : {
+            "text" : "Inefficient regular expression"
+          },
+          "fullDescription" : {
+            "text" : "A regular expression that requires exponential time to match certain inputs can be a performance bottleneck, and may be vulnerable to denial-of-service attacks."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-730", "external/cwe/cwe-400" ],
+            "description" : "A regular expression that requires exponential time to match certain inputs\n              can be a performance bottleneck, and may be vulnerable to denial-of-service\n              attacks.",
+            "id" : "java/redos",
+            "kind" : "problem",
+            "name" : "Inefficient regular expression",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "7.5"
+          }
+        }, {
+          "id" : "java/world-writable-file-read",
+          "name" : "java/world-writable-file-read",
+          "shortDescription" : {
+            "text" : "Reading from a world writable file"
+          },
+          "fullDescription" : {
+            "text" : "Reading from a file which is set as world writable is dangerous because the file may be modified or removed by external actors."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-732" ],
+            "description" : "Reading from a file which is set as world writable is dangerous because\n              the file may be modified or removed by external actors.",
+            "id" : "java/world-writable-file-read",
+            "kind" : "problem",
+            "name" : "Reading from a world writable file",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "7.8"
+          }
+        }, {
+          "id" : "java/tainted-permissions-check",
+          "name" : "java/tainted-permissions-check",
+          "shortDescription" : {
+            "text" : "User-controlled data used in permissions check"
+          },
+          "fullDescription" : {
+            "text" : "Using user-controlled data in a permissions check may result in inappropriate permissions being granted."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-807", "external/cwe/cwe-290" ],
+            "description" : "Using user-controlled data in a permissions check may result in inappropriate\n              permissions being granted.",
+            "id" : "java/tainted-permissions-check",
+            "kind" : "path-problem",
+            "name" : "User-controlled data used in permissions check",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "7.8"
+          }
+        }, {
+          "id" : "java/maven/non-https-url",
+          "name" : "java/maven/non-https-url",
+          "shortDescription" : {
+            "text" : "Failure to use HTTPS or SFTP URL in Maven artifact upload/download"
+          },
+          "fullDescription" : {
+            "text" : "Non-HTTPS connections can be intercepted by third parties."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-300", "external/cwe/cwe-319", "external/cwe/cwe-494", "external/cwe/cwe-829" ],
+            "description" : "Non-HTTPS connections can be intercepted by third parties.",
+            "id" : "java/maven/non-https-url",
+            "kind" : "problem",
+            "name" : "Failure to use HTTPS or SFTP URL in Maven artifact upload/download",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "security-severity" : "8.1"
+          }
+        }, {
+          "id" : "java/ognl-injection",
+          "name" : "java/ognl-injection",
+          "shortDescription" : {
+            "text" : "OGNL Expression Language statement with user-controlled input"
+          },
+          "fullDescription" : {
+            "text" : "Evaluation of OGNL Expression Language statement with user-controlled input can lead to execution of arbitrary code."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-917" ],
+            "description" : "Evaluation of OGNL Expression Language statement with user-controlled input can\n                lead to execution of arbitrary code.",
+            "id" : "java/ognl-injection",
+            "kind" : "path-problem",
+            "name" : "OGNL Expression Language statement with user-controlled input",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.8"
+          }
+        }, {
+          "id" : "java/ssrf",
+          "name" : "java/ssrf",
+          "shortDescription" : {
+            "text" : "Server-side request forgery"
+          },
+          "fullDescription" : {
+            "text" : "Making web requests based on unvalidated user-input may cause the server to communicate with malicious servers."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-918" ],
+            "description" : "Making web requests based on unvalidated user-input\n              may cause the server to communicate with malicious servers.",
+            "id" : "java/ssrf",
+            "kind" : "path-problem",
+            "name" : "Server-side request forgery",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.1"
+          }
+        }, {
+          "id" : "java/android/implicit-pendingintents",
+          "name" : "java/android/implicit-pendingintents",
+          "shortDescription" : {
+            "text" : "Use of implicit PendingIntents"
+          },
+          "fullDescription" : {
+            "text" : "Sending an implicit and mutable 'PendingIntent' to an unspecified third party component may provide an attacker with access to internal components of the application or cause other unintended effects."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-927" ],
+            "description" : "Sending an implicit and mutable 'PendingIntent' to an unspecified third party\n              component may provide an attacker with access to internal components of the\n              application or cause other unintended effects.",
+            "id" : "java/android/implicit-pendingintents",
+            "kind" : "path-problem",
+            "name" : "Use of implicit PendingIntents",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "8.2"
+          }
+        }, {
+          "id" : "java/android/intent-redirection",
+          "name" : "java/android/intent-redirection",
+          "shortDescription" : {
+            "text" : "Android Intent redirection"
+          },
+          "fullDescription" : {
+            "text" : "Starting Android components with user-provided Intents can provide access to internal components of the application, increasing the attack surface and potentially causing unintended effects."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-926", "external/cwe/cwe-940" ],
+            "description" : "Starting Android components with user-provided Intents\n              can provide access to internal components of the application,\n              increasing the attack surface and potentially causing unintended effects.",
+            "id" : "java/android/intent-redirection",
+            "kind" : "path-problem",
+            "name" : "Android Intent redirection",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "7.5"
+          }
+        }, {
+          "id" : "java/summary/lines-of-code",
+          "name" : "java/summary/lines-of-code",
+          "shortDescription" : {
+            "text" : "Total lines of code in the database"
+          },
+          "fullDescription" : {
+            "text" : "The total number of lines of code across all files. This is a useful metric of the size of a database. For all files that were seen during the build, this query counts the lines of code, excluding whitespace or comments."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true
+          },
+          "properties" : {
+            "tags" : [ "summary", "lines-of-code" ],
+            "description" : "The total number of lines of code across all files. This is a useful metric of the size of a database.\n              For all files that were seen during the build, this query counts the lines of code, excluding whitespace\n              or comments.",
+            "id" : "java/summary/lines-of-code",
+            "kind" : "metric",
+            "name" : "Total lines of code in the database"
+          }
+        }, {
+          "id" : "java/telemetry/external-libs",
+          "name" : "java/telemetry/external-libs",
+          "shortDescription" : {
+            "text" : "External libraries"
+          },
+          "fullDescription" : {
+            "text" : "A list of external libraries used in the code"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true
+          },
+          "properties" : {
+            "tags" : [ "summary", "telemetry" ],
+            "description" : "A list of external libraries used in the code",
+            "id" : "java/telemetry/external-libs",
+            "kind" : "metric",
+            "name" : "External libraries"
+          }
+        }, {
+          "id" : "java/telemetry/supported-external-api-sinks",
+          "name" : "java/telemetry/supported-external-api-sinks",
+          "shortDescription" : {
+            "text" : "Supported sinks in external libraries"
+          },
+          "fullDescription" : {
+            "text" : "A list of 3rd party APIs detected as sinks. Excludes test and generated code."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true
+          },
+          "properties" : {
+            "tags" : [ "summary", "telemetry" ],
+            "description" : "A list of 3rd party APIs detected as sinks. Excludes test and generated code.",
+            "id" : "java/telemetry/supported-external-api-sinks",
+            "kind" : "metric",
+            "name" : "Supported sinks in external libraries"
+          }
+        }, {
+          "id" : "java/telemetry/supported-external-api-sources",
+          "name" : "java/telemetry/supported-external-api-sources",
+          "shortDescription" : {
+            "text" : "Supported sources in external libraries"
+          },
+          "fullDescription" : {
+            "text" : "A list of 3rd party APIs detected as sources. Excludes test and generated code."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true
+          },
+          "properties" : {
+            "tags" : [ "summary", "telemetry" ],
+            "description" : "A list of 3rd party APIs detected as sources. Excludes test and generated code.",
+            "id" : "java/telemetry/supported-external-api-sources",
+            "kind" : "metric",
+            "name" : "Supported sources in external libraries"
+          }
+        }, {
+          "id" : "java/telemetry/supported-external-api-taint",
+          "name" : "java/telemetry/supported-external-api-taint",
+          "shortDescription" : {
+            "text" : "Supported flow steps in external libraries"
+          },
+          "fullDescription" : {
+            "text" : "A list of 3rd party APIs detected as flow steps. Excludes test and generated code."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true
+          },
+          "properties" : {
+            "tags" : [ "summary", "telemetry" ],
+            "description" : "A list of 3rd party APIs detected as flow steps. Excludes test and generated code.",
+            "id" : "java/telemetry/supported-external-api-taint",
+            "kind" : "metric",
+            "name" : "Supported flow steps in external libraries"
+          }
+        }, {
+          "id" : "java/telemetry/unsupported-external-api",
+          "name" : "java/telemetry/unsupported-external-api",
+          "shortDescription" : {
+            "text" : "Usage of unsupported APIs coming from external libraries"
+          },
+          "fullDescription" : {
+            "text" : "A list of 3rd party APIs used in the codebase. Excludes test and generated code."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true
+          },
+          "properties" : {
+            "tags" : [ "summary", "telemetry" ],
+            "description" : "A list of 3rd party APIs used in the codebase. Excludes test and generated code.",
+            "id" : "java/telemetry/unsupported-external-api",
+            "kind" : "metric",
+            "name" : "Usage of unsupported APIs coming from external libraries"
+          }
+        } ]
+      },
+      "extensions" : [ {
+        "name" : "codeql/go-all",
+        "semanticVersion" : "0.1.3+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/go-all/0.1.3/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/go-all/0.1.3/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/go-examples",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/go-examples/0.0.0/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/go-examples/0.0.0/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/java-all",
+        "semanticVersion" : "0.2.2+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/java-all/0.2.2/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/java-all/0.2.2/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/ruby-queries",
+        "semanticVersion" : "0.1.3+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/ruby-queries/0.1.3/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/ruby-queries/0.1.3/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/csharp-all",
+        "semanticVersion" : "0.2.2+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/csharp-all/0.2.2/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/csharp-all/0.2.2/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/javascript-examples",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/javascript-examples/0.0.0/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/javascript-examples/0.0.0/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/ruby-all",
+        "semanticVersion" : "0.2.2+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/ruby-all/0.2.2/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/ruby-all/0.2.2/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/ruby-examples",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/ruby-examples/0.0.0/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/ruby-examples/0.0.0/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/cpp-queries",
+        "semanticVersion" : "0.1.3+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/cpp-queries/0.1.3/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/cpp-queries/0.1.3/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/java-examples",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/java-examples/0.0.0/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/java-examples/0.0.0/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/python-queries",
+        "semanticVersion" : "0.1.3+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/python-queries/0.1.3/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/python-queries/0.1.3/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/suite-helpers",
+        "semanticVersion" : "0.1.0+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/suite-helpers/0.1.0/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/suite-helpers/0.1.0/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/python-examples",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/python-examples/0.0.0/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/python-examples/0.0.0/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/javascript-queries",
+        "semanticVersion" : "0.1.3+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/javascript-queries/0.1.3/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/javascript-queries/0.1.3/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/go-queries",
+        "semanticVersion" : "0.1.3+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/go-queries/0.1.3/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/go-queries/0.1.3/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/cpp-all",
+        "semanticVersion" : "0.2.2+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/cpp-all/0.2.2/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/cpp-all/0.2.2/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/python-all",
+        "semanticVersion" : "0.4.0+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/python-all/0.4.0/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/python-all/0.4.0/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "legacy-upgrades",
+        "semanticVersion" : "0.0.0",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/legacy-upgrades/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/legacy-upgrades/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/csharp-examples",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/csharp-examples/0.0.0/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/csharp-examples/0.0.0/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/java-queries",
+        "semanticVersion" : "0.1.3+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/java-queries/0.1.3/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/java-queries/0.1.3/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/javascript-all",
+        "semanticVersion" : "0.1.3+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/javascript-all/0.1.3/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/javascript-all/0.1.3/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/csharp-queries",
+        "semanticVersion" : "0.1.3+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/csharp-queries/0.1.3/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/csharp-queries/0.1.3/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/cpp-examples",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/cpp-examples/0.0.0/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/cpp-examples/0.0.0/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      } ]
+    },
+    "invocations" : [ {
+      "toolExecutionNotifications" : [ {
+        "locations" : [ {
+          "physicalLocation" : {
+            "artifactLocation" : {
+              "uri" : "src/main/java/com/mycompany/app/App.java",
+              "uriBaseId" : "%SRCROOT%",
+              "index" : 0
+            }
+          }
+        } ],
+        "message" : {
+          "text" : ""
+        },
+        "level" : "none",
+        "descriptor" : {
+          "id" : "java/diagnostics/successfully-extracted-files",
+          "index" : 2
+        },
+        "properties" : {
+          "formattedMessage" : {
+            "text" : ""
+          },
+          "relatedLocations" : [ ]
+        }
+      }, {
+        "locations" : [ {
+          "physicalLocation" : {
+            "artifactLocation" : {
+              "uri" : "src/test/java/com/mycompany/app/AppTest.java",
+              "uriBaseId" : "%SRCROOT%",
+              "index" : 1
+            }
+          }
+        } ],
+        "message" : {
+          "text" : ""
+        },
+        "level" : "none",
+        "descriptor" : {
+          "id" : "java/diagnostics/successfully-extracted-files",
+          "index" : 2
+        },
+        "properties" : {
+          "formattedMessage" : {
+            "text" : ""
+          },
+          "relatedLocations" : [ ]
+        }
+      } ],
+      "executionSuccessful" : true
+    } ],
+    "artifacts" : [ {
+      "location" : {
+        "uri" : "src/main/java/com/mycompany/app/App.java",
+        "uriBaseId" : "%SRCROOT%",
+        "index" : 0
+      }
+    }, {
+      "location" : {
+        "uri" : "src/test/java/com/mycompany/app/AppTest.java",
+        "uriBaseId" : "%SRCROOT%",
+        "index" : 1
+      }
+    } ],
+    "results" : [ ],
+    "automationDetails" : {
+      "id" : ".github/workflows/codeql-analysis.yml:analyze/language:java/"
+    },
+    "columnKind" : "utf16CodeUnits",
+    "properties" : {
+      "metricResults" : [ {
+        "rule" : {
+          "id" : "java/summary/lines-of-code",
+          "index" : 46
+        },
+        "ruleId" : "java/summary/lines-of-code",
+        "ruleIndex" : 46,
+        "value" : 19,
+        "baseline" : 19
+      }, {
+        "rule" : {
+          "id" : "java/telemetry/external-libs",
+          "index" : 47
+        },
+        "ruleId" : "java/telemetry/external-libs",
+        "ruleIndex" : 47,
+        "value" : 1,
+        "message" : {
+          "text" : "rt.jar"
+        }
+      }, {
+        "rule" : {
+          "id" : "java/telemetry/supported-external-api-sinks",
+          "index" : 48
+        },
+        "ruleId" : "java/telemetry/supported-external-api-sinks",
+        "ruleIndex" : 48,
+        "value" : 1,
+        "message" : {
+          "text" : "java.io.PrintStream#println(String)"
+        }
+      } ],
+      "semmle.formatSpecifier" : "sarif-latest"
+    }
+  } ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.mycompany.app</groupId>
+  <artifactId>my-app</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>my-app</name>
+  <!-- FIXME change it to the project's website -->
+  <url>http://www.example.com</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+      <plugins>
+        <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+        <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.7.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/python-results.sarif
+++ b/python-results.sarif
@@ -4140,57 +4140,9 @@
         "locations" : [ {
           "physicalLocation" : {
             "artifactLocation" : {
-              "uri" : "server/models/books.py",
+              "uri" : "server/__init__.py",
               "uriBaseId" : "%SRCROOT%",
               "index" : 4
-            }
-          }
-        } ],
-        "message" : {
-          "text" : ""
-        },
-        "level" : "none",
-        "descriptor" : {
-          "id" : "py/diagnostics/successfully-extracted-files",
-          "index" : 1
-        },
-        "properties" : {
-          "formattedMessage" : {
-            "text" : ""
-          },
-          "relatedLocations" : [ ]
-        }
-      }, {
-        "locations" : [ {
-          "physicalLocation" : {
-            "artifactLocation" : {
-              "uri" : "server/routes.py",
-              "uriBaseId" : "%SRCROOT%",
-              "index" : 2
-            }
-          }
-        } ],
-        "message" : {
-          "text" : ""
-        },
-        "level" : "none",
-        "descriptor" : {
-          "id" : "py/diagnostics/successfully-extracted-files",
-          "index" : 1
-        },
-        "properties" : {
-          "formattedMessage" : {
-            "text" : ""
-          },
-          "relatedLocations" : [ ]
-        }
-      }, {
-        "locations" : [ {
-          "physicalLocation" : {
-            "artifactLocation" : {
-              "uri" : "server/webapp.py",
-              "uriBaseId" : "%SRCROOT%",
-              "index" : 3
             }
           }
         } ],
@@ -4260,9 +4212,57 @@
         "locations" : [ {
           "physicalLocation" : {
             "artifactLocation" : {
-              "uri" : "server/__init__.py",
+              "uri" : "server/webapp.py",
+              "uriBaseId" : "%SRCROOT%",
+              "index" : 3
+            }
+          }
+        } ],
+        "message" : {
+          "text" : ""
+        },
+        "level" : "none",
+        "descriptor" : {
+          "id" : "py/diagnostics/successfully-extracted-files",
+          "index" : 1
+        },
+        "properties" : {
+          "formattedMessage" : {
+            "text" : ""
+          },
+          "relatedLocations" : [ ]
+        }
+      }, {
+        "locations" : [ {
+          "physicalLocation" : {
+            "artifactLocation" : {
+              "uri" : "server/models/books.py",
               "uriBaseId" : "%SRCROOT%",
               "index" : 6
+            }
+          }
+        } ],
+        "message" : {
+          "text" : ""
+        },
+        "level" : "none",
+        "descriptor" : {
+          "id" : "py/diagnostics/successfully-extracted-files",
+          "index" : 1
+        },
+        "properties" : {
+          "formattedMessage" : {
+            "text" : ""
+          },
+          "relatedLocations" : [ ]
+        }
+      }, {
+        "locations" : [ {
+          "physicalLocation" : {
+            "artifactLocation" : {
+              "uri" : "server/routes.py",
+              "uriBaseId" : "%SRCROOT%",
+              "index" : 2
             }
           }
         } ],
@@ -4308,7 +4308,7 @@
       }
     }, {
       "location" : {
-        "uri" : "server/models/books.py",
+        "uri" : "server/__init__.py",
         "uriBaseId" : "%SRCROOT%",
         "index" : 4
       }
@@ -4320,7 +4320,7 @@
       }
     }, {
       "location" : {
-        "uri" : "server/__init__.py",
+        "uri" : "server/models/books.py",
         "uriBaseId" : "%SRCROOT%",
         "index" : 6
       }

--- a/results.sarif
+++ b/results.sarif
@@ -1,0 +1,4948 @@
+{
+  "$schema" : "https://json.schemastore.org/sarif-2.1.0.json",
+  "version" : "2.1.0",
+  "runs" : [ {
+    "tool" : {
+      "driver" : {
+        "name" : "CodeQL",
+        "organization" : "GitHub",
+        "semanticVersion" : "2.9.3",
+        "notifications" : [ {
+          "id" : "py/diagnostics/extraction-warnings",
+          "name" : "py/diagnostics/extraction-warnings",
+          "shortDescription" : {
+            "text" : "Python extraction warnings"
+          },
+          "fullDescription" : {
+            "text" : "List all extraction warnings for Python files in the source code directory."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true
+          },
+          "properties" : {
+            "description" : "List all extraction warnings for Python files in the source code directory.",
+            "id" : "py/diagnostics/extraction-warnings",
+            "kind" : "diagnostic",
+            "name" : "Python extraction warnings"
+          }
+        }, {
+          "id" : "py/diagnostics/successfully-extracted-files",
+          "name" : "py/diagnostics/successfully-extracted-files",
+          "shortDescription" : {
+            "text" : "Successfully extracted Python files"
+          },
+          "fullDescription" : {
+            "text" : "Lists all Python files in the source code directory that were extracted without encountering an error."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true
+          },
+          "properties" : {
+            "description" : "Lists all Python files in the source code directory that were extracted\n   without encountering an error.",
+            "id" : "py/diagnostics/successfully-extracted-files",
+            "kind" : "diagnostic",
+            "name" : "Successfully extracted Python files"
+          }
+        } ],
+        "rules" : [ {
+          "id" : "py/conflicting-attributes",
+          "name" : "py/conflicting-attributes",
+          "shortDescription" : {
+            "text" : "Conflicting attributes in base classes"
+          },
+          "fullDescription" : {
+            "text" : "When a class subclasses multiple base classes and more than one base class defines the same attribute, attribute overriding may result in unexpected behavior by instances of this class."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "maintainability", "modularity" ],
+            "description" : "When a class subclasses multiple base classes and more than one base class defines the same attribute, attribute overriding may result in unexpected behavior by instances of this class.",
+            "id" : "py/conflicting-attributes",
+            "kind" : "problem",
+            "name" : "Conflicting attributes in base classes",
+            "precision" : "high",
+            "problem.severity" : "warning",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/missing-equals",
+          "name" : "py/missing-equals",
+          "shortDescription" : {
+            "text" : "`__eq__` not overridden when adding attributes"
+          },
+          "fullDescription" : {
+            "text" : "When adding new attributes to instances of a class, equality for that class needs to be defined."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "When adding new attributes to instances of a class, equality for that class needs to be defined.",
+            "id" : "py/missing-equals",
+            "kind" : "problem",
+            "name" : "`__eq__` not overridden when adding attributes",
+            "precision" : "high",
+            "problem.severity" : "warning",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/equals-hash-mismatch",
+          "name" : "py/equals-hash-mismatch",
+          "shortDescription" : {
+            "text" : "Inconsistent equality and hashing"
+          },
+          "fullDescription" : {
+            "text" : "Defining equality for a class without also defining hashability (or vice-versa) violates the object model."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness", "external/cwe/cwe-581" ],
+            "description" : "Defining equality for a class without also defining hashability (or vice-versa) violates the object model.",
+            "id" : "py/equals-hash-mismatch",
+            "kind" : "problem",
+            "name" : "Inconsistent equality and hashing",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/inconsistent-equality",
+          "name" : "py/inconsistent-equality",
+          "shortDescription" : {
+            "text" : "Inconsistent equality and inequality"
+          },
+          "fullDescription" : {
+            "text" : "Defining only an equality method or an inequality method for a class violates the object model."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "Defining only an equality method or an inequality method for a class violates the object model.",
+            "id" : "py/inconsistent-equality",
+            "kind" : "problem",
+            "name" : "Inconsistent equality and inequality",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/incomplete-ordering",
+          "name" : "py/incomplete-ordering",
+          "shortDescription" : {
+            "text" : "Incomplete ordering"
+          },
+          "fullDescription" : {
+            "text" : "Class defines one or more ordering method but does not define all 4 ordering comparison methods"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "Class defines one or more ordering method but does not define all 4 ordering comparison methods",
+            "id" : "py/incomplete-ordering",
+            "kind" : "problem",
+            "name" : "Incomplete ordering",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/inconsistent-mro",
+          "name" : "py/inconsistent-mro",
+          "shortDescription" : {
+            "text" : "Inconsistent method resolution order"
+          },
+          "fullDescription" : {
+            "text" : "Class definition will raise a type error at runtime due to inconsistent method resolution order(MRO)"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "Class definition will raise a type error at runtime due to inconsistent method resolution order(MRO)",
+            "id" : "py/inconsistent-mro",
+            "kind" : "problem",
+            "name" : "Inconsistent method resolution order",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/init-calls-subclass",
+          "name" : "py/init-calls-subclass",
+          "shortDescription" : {
+            "text" : "`__init__` method calls overridden method"
+          },
+          "fullDescription" : {
+            "text" : "Calling a method from `__init__` that is overridden by a subclass may result in a partially initialized instance being observed."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "Calling a method from `__init__` that is overridden by a subclass may result in a partially\n              initialized instance being observed.",
+            "id" : "py/init-calls-subclass",
+            "kind" : "problem",
+            "name" : "`__init__` method calls overridden method",
+            "precision" : "high",
+            "problem.severity" : "warning",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/missing-call-to-delete",
+          "name" : "py/missing-call-to-delete",
+          "shortDescription" : {
+            "text" : "Missing call to `__del__` during object destruction"
+          },
+          "fullDescription" : {
+            "text" : "An omitted call to a super-class `__del__` method may lead to class instances not being cleaned up properly."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "efficiency", "correctness" ],
+            "description" : "An omitted call to a super-class `__del__` method may lead to class instances not being cleaned up properly.",
+            "id" : "py/missing-call-to-delete",
+            "kind" : "problem",
+            "name" : "Missing call to `__del__` during object destruction",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/missing-call-to-init",
+          "name" : "py/missing-call-to-init",
+          "shortDescription" : {
+            "text" : "Missing call to `__init__` during object initialization"
+          },
+          "fullDescription" : {
+            "text" : "An omitted call to a super-class `__init__` method may lead to objects of this class not being fully initialized."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "An omitted call to a super-class `__init__` method may lead to objects of this class not being fully initialized.",
+            "id" : "py/missing-call-to-init",
+            "kind" : "problem",
+            "name" : "Missing call to `__init__` during object initialization",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/mutable-descriptor",
+          "name" : "py/mutable-descriptor",
+          "shortDescription" : {
+            "text" : "Mutation of descriptor in `__get__` or `__set__` method."
+          },
+          "fullDescription" : {
+            "text" : "Descriptor objects can be shared across many instances. Mutating them can cause strange side effects or race conditions."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "Descriptor objects can be shared across many instances. Mutating them can cause strange side effects or race conditions.",
+            "id" : "py/mutable-descriptor",
+            "kind" : "problem",
+            "name" : "Mutation of descriptor in `__get__` or `__set__` method.",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/property-in-old-style-class",
+          "name" : "py/property-in-old-style-class",
+          "shortDescription" : {
+            "text" : "Property in old-style class"
+          },
+          "fullDescription" : {
+            "text" : "Using property descriptors in old-style classes does not work from Python 2.1 onward."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "portability", "correctness" ],
+            "description" : "Using property descriptors in old-style classes does not work from Python 2.1 onward.",
+            "id" : "py/property-in-old-style-class",
+            "kind" : "problem",
+            "name" : "Property in old-style class",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/slots-in-old-style-class",
+          "name" : "py/slots-in-old-style-class",
+          "shortDescription" : {
+            "text" : "`__slots__` in old-style class"
+          },
+          "fullDescription" : {
+            "text" : "Overriding the class dictionary by declaring `__slots__` is not supported by old-style classes."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "portability", "correctness" ],
+            "description" : "Overriding the class dictionary by declaring `__slots__` is not supported by old-style\n              classes.",
+            "id" : "py/slots-in-old-style-class",
+            "kind" : "problem",
+            "name" : "`__slots__` in old-style class",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/attribute-shadows-method",
+          "name" : "py/attribute-shadows-method",
+          "shortDescription" : {
+            "text" : "Superclass attribute shadows subclass method"
+          },
+          "fullDescription" : {
+            "text" : "Defining an attribute in a superclass method with a name that matches a subclass method, hides the method in the subclass."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "correctness" ],
+            "description" : "Defining an attribute in a superclass method with a name that matches a subclass\n              method, hides the method in the subclass.",
+            "id" : "py/attribute-shadows-method",
+            "kind" : "problem",
+            "name" : "Superclass attribute shadows subclass method",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/super-in-old-style",
+          "name" : "py/super-in-old-style",
+          "shortDescription" : {
+            "text" : "'super' in old style class"
+          },
+          "fullDescription" : {
+            "text" : "Using super() to access inherited methods is not supported by old-style classes."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "portability", "correctness" ],
+            "description" : "Using super() to access inherited methods is not supported by old-style classes.",
+            "id" : "py/super-in-old-style",
+            "kind" : "problem",
+            "name" : "'super' in old style class",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/multiple-calls-to-delete",
+          "name" : "py/multiple-calls-to-delete",
+          "shortDescription" : {
+            "text" : "Multiple calls to `__del__` during object destruction"
+          },
+          "fullDescription" : {
+            "text" : "A duplicated call to a super-class `__del__` method may lead to class instances not be cleaned up properly."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "efficiency", "correctness" ],
+            "description" : "A duplicated call to a super-class `__del__` method may lead to class instances not be cleaned up properly.",
+            "id" : "py/multiple-calls-to-delete",
+            "kind" : "problem",
+            "name" : "Multiple calls to `__del__` during object destruction",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/multiple-calls-to-init",
+          "name" : "py/multiple-calls-to-init",
+          "shortDescription" : {
+            "text" : "Multiple calls to `__init__` during object initialization"
+          },
+          "fullDescription" : {
+            "text" : "A duplicated call to a super-class `__init__` method may lead to objects of this class not being properly initialized."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "A duplicated call to a super-class `__init__` method may lead to objects of this class not being properly initialized.",
+            "id" : "py/multiple-calls-to-init",
+            "kind" : "problem",
+            "name" : "Multiple calls to `__init__` during object initialization",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/call/wrong-named-class-argument",
+          "name" : "py/call/wrong-named-class-argument",
+          "shortDescription" : {
+            "text" : "Wrong name for an argument in a class instantiation"
+          },
+          "fullDescription" : {
+            "text" : "Using a named argument whose name does not correspond to a parameter of the __init__ method of the class being instantiated, will result in a TypeError at runtime."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness", "external/cwe/cwe-628" ],
+            "description" : "Using a named argument whose name does not correspond to a\n              parameter of the __init__ method of the class being\n              instantiated, will result in a TypeError at runtime.",
+            "id" : "py/call/wrong-named-class-argument",
+            "kind" : "problem",
+            "name" : "Wrong name for an argument in a class instantiation",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/call/wrong-number-class-arguments",
+          "name" : "py/call/wrong-number-class-arguments",
+          "shortDescription" : {
+            "text" : "Wrong number of arguments in a class instantiation"
+          },
+          "fullDescription" : {
+            "text" : "Using too many or too few arguments in a call to the `__init__` method of a class will result in a TypeError at runtime."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness", "external/cwe/cwe-685" ],
+            "description" : "Using too many or too few arguments in a call to the `__init__`\n              method of a class will result in a TypeError at runtime.",
+            "id" : "py/call/wrong-number-class-arguments",
+            "kind" : "problem",
+            "name" : "Wrong number of arguments in a class instantiation",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/catch-base-exception",
+          "name" : "py/catch-base-exception",
+          "shortDescription" : {
+            "text" : "Except block handles 'BaseException'"
+          },
+          "fullDescription" : {
+            "text" : "Handling 'BaseException' means that system exits and keyboard interrupts may be mis-handled."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "readability", "convention", "external/cwe/cwe-396" ],
+            "description" : "Handling 'BaseException' means that system exits and keyboard interrupts may be mis-handled.",
+            "id" : "py/catch-base-exception",
+            "kind" : "problem",
+            "name" : "Except block handles 'BaseException'",
+            "precision" : "very-high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/empty-except",
+          "name" : "py/empty-except",
+          "shortDescription" : {
+            "text" : "Empty except"
+          },
+          "fullDescription" : {
+            "text" : "Except doesn't do anything and has no comment"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "maintainability", "external/cwe/cwe-390" ],
+            "description" : "Except doesn't do anything and has no comment",
+            "id" : "py/empty-except",
+            "kind" : "problem",
+            "name" : "Empty except",
+            "precision" : "high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/useless-except",
+          "name" : "py/useless-except",
+          "shortDescription" : {
+            "text" : "Non-exception in 'except' clause"
+          },
+          "fullDescription" : {
+            "text" : "An exception handler specifying a non-exception type will never handle any exception."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness", "types" ],
+            "description" : "An exception handler specifying a non-exception type will never handle any exception.",
+            "id" : "py/useless-except",
+            "kind" : "problem",
+            "name" : "Non-exception in 'except' clause",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/illegal-raise",
+          "name" : "py/illegal-raise",
+          "shortDescription" : {
+            "text" : "Illegal raise"
+          },
+          "fullDescription" : {
+            "text" : "Raising a non-exception object or type will result in a TypeError being raised instead."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness", "types" ],
+            "description" : "Raising a non-exception object or type will result in a TypeError being raised instead.",
+            "id" : "py/illegal-raise",
+            "kind" : "problem",
+            "name" : "Illegal raise",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/unreachable-except",
+          "name" : "py/unreachable-except",
+          "shortDescription" : {
+            "text" : "Unreachable 'except' block"
+          },
+          "fullDescription" : {
+            "text" : "Handling general exceptions before specific exceptions means that the specific handlers are never executed."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "maintainability", "external/cwe/cwe-561" ],
+            "description" : "Handling general exceptions before specific exceptions means that the specific\n              handlers are never executed.",
+            "id" : "py/unreachable-except",
+            "kind" : "problem",
+            "name" : "Unreachable 'except' block",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/raise-not-implemented",
+          "name" : "py/raise-not-implemented",
+          "shortDescription" : {
+            "text" : "NotImplemented is not an Exception"
+          },
+          "fullDescription" : {
+            "text" : "Using 'NotImplemented' as an exception will result in a type error."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "maintainability" ],
+            "description" : "Using 'NotImplemented' as an exception will result in a type error.",
+            "id" : "py/raise-not-implemented",
+            "kind" : "problem",
+            "name" : "NotImplemented is not an Exception",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/raises-tuple",
+          "name" : "py/raises-tuple",
+          "shortDescription" : {
+            "text" : "Raising a tuple"
+          },
+          "fullDescription" : {
+            "text" : "Raising a tuple will result in all but the first element being discarded"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "maintainability" ],
+            "description" : "Raising a tuple will result in all but the first element being discarded",
+            "id" : "py/raises-tuple",
+            "kind" : "problem",
+            "name" : "Raising a tuple",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/unguarded-next-in-generator",
+          "name" : "py/unguarded-next-in-generator",
+          "shortDescription" : {
+            "text" : "Unguarded next in generator"
+          },
+          "fullDescription" : {
+            "text" : "Calling next() in a generator may cause unintended early termination of an iteration."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "portability" ],
+            "description" : "Calling next() in a generator may cause unintended early termination of an iteration.",
+            "id" : "py/unguarded-next-in-generator",
+            "kind" : "problem",
+            "name" : "Unguarded next in generator",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/super-not-enclosing-class",
+          "name" : "py/super-not-enclosing-class",
+          "shortDescription" : {
+            "text" : "First argument to super() is not enclosing class"
+          },
+          "fullDescription" : {
+            "text" : "Calling super with something other than the enclosing class may cause incorrect object initialization."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "maintainability", "convention", "external/cwe/cwe-687" ],
+            "description" : "Calling super with something other than the enclosing class may cause incorrect object initialization.",
+            "id" : "py/super-not-enclosing-class",
+            "kind" : "problem",
+            "name" : "First argument to super() is not enclosing class",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/comparison-of-constants",
+          "name" : "py/comparison-of-constants",
+          "shortDescription" : {
+            "text" : "Comparison of constants"
+          },
+          "fullDescription" : {
+            "text" : "Comparison of constants is always constant, but is harder to read than a simple constant."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "useless-code", "external/cwe/cwe-570", "external/cwe/cwe-571" ],
+            "description" : "Comparison of constants is always constant, but is harder to read than a simple constant.",
+            "id" : "py/comparison-of-constants",
+            "kind" : "problem",
+            "name" : "Comparison of constants",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/comparison-of-identical-expressions",
+          "name" : "py/comparison-of-identical-expressions",
+          "shortDescription" : {
+            "text" : "Comparison of identical values"
+          },
+          "fullDescription" : {
+            "text" : "Comparison of identical values, the intent of which is unclear."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness", "readability", "convention", "external/cwe/cwe-570", "external/cwe/cwe-571" ],
+            "description" : "Comparison of identical values, the intent of which is unclear.",
+            "id" : "py/comparison-of-identical-expressions",
+            "kind" : "problem",
+            "name" : "Comparison of identical values",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/comparison-missing-self",
+          "name" : "py/comparison-missing-self",
+          "shortDescription" : {
+            "text" : "Maybe missing 'self' in comparison"
+          },
+          "fullDescription" : {
+            "text" : "Comparison of identical values, the intent of which is unclear."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "maintainability", "external/cwe/cwe-570", "external/cwe/cwe-571" ],
+            "description" : "Comparison of identical values, the intent of which is unclear.",
+            "id" : "py/comparison-missing-self",
+            "kind" : "problem",
+            "name" : "Maybe missing 'self' in comparison",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/redundant-comparison",
+          "name" : "py/redundant-comparison",
+          "shortDescription" : {
+            "text" : "Redundant comparison"
+          },
+          "fullDescription" : {
+            "text" : "The result of a comparison is implied by a previous comparison."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "useless-code", "external/cwe/cwe-561", "external/cwe/cwe-570", "external/cwe/cwe-571" ],
+            "description" : "The result of a comparison is implied by a previous comparison.",
+            "id" : "py/redundant-comparison",
+            "kind" : "problem",
+            "name" : "Redundant comparison",
+            "precision" : "high",
+            "problem.severity" : "warning",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/member-test-non-container",
+          "name" : "py/member-test-non-container",
+          "shortDescription" : {
+            "text" : "Membership test with a non-container"
+          },
+          "fullDescription" : {
+            "text" : "A membership test, such as 'item in sequence', with a non-container on the right hand side will raise a 'TypeError'."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "A membership test, such as 'item in sequence', with a non-container on the right hand side will raise a 'TypeError'.",
+            "id" : "py/member-test-non-container",
+            "kind" : "problem",
+            "name" : "Membership test with a non-container",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/duplicate-key-dict-literal",
+          "name" : "py/duplicate-key-dict-literal",
+          "shortDescription" : {
+            "text" : "Duplicate key in dict literal"
+          },
+          "fullDescription" : {
+            "text" : "Duplicate key in dict literal. All but the last will be lost."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "useless-code", "external/cwe/cwe-561" ],
+            "description" : "Duplicate key in dict literal. All but the last will be lost.",
+            "id" : "py/duplicate-key-dict-literal",
+            "kind" : "problem",
+            "name" : "Duplicate key in dict literal",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/test-equals-none",
+          "name" : "py/test-equals-none",
+          "shortDescription" : {
+            "text" : "Testing equality to None"
+          },
+          "fullDescription" : {
+            "text" : "Testing whether an object is 'None' using the == operator is inefficient and potentially incorrect."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "efficiency", "maintainability" ],
+            "description" : "Testing whether an object is 'None' using the == operator is inefficient and potentially incorrect.",
+            "id" : "py/test-equals-none",
+            "kind" : "problem",
+            "name" : "Testing equality to None",
+            "precision" : "very-high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/percent-format/not-mapping",
+          "name" : "py/percent-format/not-mapping",
+          "shortDescription" : {
+            "text" : "Formatted object is not a mapping"
+          },
+          "fullDescription" : {
+            "text" : "The formatted object must be a mapping when the format includes a named specifier; otherwise a TypeError will be raised.\""
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "The formatted object must be a mapping when the format includes a named specifier; otherwise a TypeError will be raised.\"",
+            "id" : "py/percent-format/not-mapping",
+            "kind" : "problem",
+            "name" : "Formatted object is not a mapping",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/explicit-call-to-delete",
+          "name" : "py/explicit-call-to-delete",
+          "shortDescription" : {
+            "text" : "`__del__` is called explicitly"
+          },
+          "fullDescription" : {
+            "text" : "The `__del__` special method is called by the virtual machine when an object is being finalized. It should not be called explicitly."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "The `__del__` special method is called by the virtual machine when an object is being finalized. It should not be called explicitly.",
+            "id" : "py/explicit-call-to-delete",
+            "kind" : "problem",
+            "name" : "`__del__` is called explicitly",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/str-format/mixed-fields",
+          "name" : "py/str-format/mixed-fields",
+          "shortDescription" : {
+            "text" : "Formatting string mixes implicitly and explicitly numbered fields"
+          },
+          "fullDescription" : {
+            "text" : "Using implicit and explicit numbering in string formatting operations, such as '\"{}: {1}\".format(a,b)', will raise a ValueError."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "Using implicit and explicit numbering in string formatting operations, such as '\"{}: {1}\".format(a,b)', will raise a ValueError.",
+            "id" : "py/str-format/mixed-fields",
+            "kind" : "problem",
+            "name" : "Formatting string mixes implicitly and explicitly numbered fields",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/str-format/surplus-argument",
+          "name" : "py/str-format/surplus-argument",
+          "shortDescription" : {
+            "text" : "Unused argument in a formatting call"
+          },
+          "fullDescription" : {
+            "text" : "Including surplus arguments in a formatting call makes code more difficult to read and may indicate an error."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "useless-code" ],
+            "description" : "Including surplus arguments in a formatting call makes code more difficult to read and may indicate an error.",
+            "id" : "py/str-format/surplus-argument",
+            "kind" : "problem",
+            "name" : "Unused argument in a formatting call",
+            "precision" : "high",
+            "problem.severity" : "warning",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/str-format/surplus-named-argument",
+          "name" : "py/str-format/surplus-named-argument",
+          "shortDescription" : {
+            "text" : "Unused named argument in formatting call"
+          },
+          "fullDescription" : {
+            "text" : "Including surplus keyword arguments in a formatting call makes code more difficult to read and may indicate an error."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "useless-code" ],
+            "description" : "Including surplus keyword arguments in a formatting call makes code more difficult to read and may indicate an error.",
+            "id" : "py/str-format/surplus-named-argument",
+            "kind" : "problem",
+            "name" : "Unused named argument in formatting call",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/str-format/missing-named-argument",
+          "name" : "py/str-format/missing-named-argument",
+          "shortDescription" : {
+            "text" : "Missing named arguments in formatting call"
+          },
+          "fullDescription" : {
+            "text" : "A string formatting operation, such as '\"{name}\".format(key=b)', where the names of format items in the format string differs from the names of the values to be formatted will raise a KeyError."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "A string formatting operation, such as '\"{name}\".format(key=b)',\n              where the names of format items in the format string differs from the names of the values to be formatted will raise a KeyError.",
+            "id" : "py/str-format/missing-named-argument",
+            "kind" : "problem",
+            "name" : "Missing named arguments in formatting call",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/str-format/missing-argument",
+          "name" : "py/str-format/missing-argument",
+          "shortDescription" : {
+            "text" : "Too few arguments in formatting call"
+          },
+          "fullDescription" : {
+            "text" : "A string formatting operation, such as '\"{0}: {1}, {2}\".format(a,b)', where the number of values to be formatted is too few for the format string will raise an IndexError."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "A string formatting operation, such as '\"{0}: {1}, {2}\".format(a,b)',\n              where the number of values to be formatted is too few for the format string will raise an IndexError.",
+            "id" : "py/str-format/missing-argument",
+            "kind" : "problem",
+            "name" : "Too few arguments in formatting call",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/hash-unhashable-value",
+          "name" : "py/hash-unhashable-value",
+          "shortDescription" : {
+            "text" : "Unhashable object hashed"
+          },
+          "fullDescription" : {
+            "text" : "Hashing an object which is not hashable will result in a TypeError at runtime."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "Hashing an object which is not hashable will result in a TypeError at runtime.",
+            "id" : "py/hash-unhashable-value",
+            "kind" : "problem",
+            "name" : "Unhashable object hashed",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/comparison-using-is",
+          "name" : "py/comparison-using-is",
+          "shortDescription" : {
+            "text" : "Comparison using is when operands support `__eq__`"
+          },
+          "fullDescription" : {
+            "text" : "Comparison using 'is' when equivalence is not the same as identity"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "Comparison using 'is' when equivalence is not the same as identity",
+            "id" : "py/comparison-using-is",
+            "kind" : "problem",
+            "name" : "Comparison using is when operands support `__eq__`",
+            "precision" : "high",
+            "problem.severity" : "warning",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/call-to-non-callable",
+          "name" : "py/call-to-non-callable",
+          "shortDescription" : {
+            "text" : "Non-callable called"
+          },
+          "fullDescription" : {
+            "text" : "A call to an object which is not a callable will raise a TypeError at runtime."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness", "types" ],
+            "description" : "A call to an object which is not a callable will raise a TypeError at runtime.",
+            "id" : "py/call-to-non-callable",
+            "kind" : "problem",
+            "name" : "Non-callable called",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/regex/backspace-escape",
+          "name" : "py/regex/backspace-escape",
+          "shortDescription" : {
+            "text" : "Backspace escape in regular expression"
+          },
+          "fullDescription" : {
+            "text" : "Using '\\b' to escape the backspace character in a regular expression is confusing since it could be mistaken for a word boundary assertion."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "maintainability" ],
+            "description" : "Using '\\b' to escape the backspace character in a regular expression is confusing\n              since it could be mistaken for a word boundary assertion.",
+            "id" : "py/regex/backspace-escape",
+            "kind" : "problem",
+            "name" : "Backspace escape in regular expression",
+            "precision" : "very-high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/regex/duplicate-in-character-class",
+          "name" : "py/regex/duplicate-in-character-class",
+          "shortDescription" : {
+            "text" : "Duplication in regular expression character class"
+          },
+          "fullDescription" : {
+            "text" : "Duplicate characters in a class have no effect and may indicate an error in the regular expression."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "readability" ],
+            "description" : "Duplicate characters in a class have no effect and may indicate an error in the regular expression.",
+            "id" : "py/regex/duplicate-in-character-class",
+            "kind" : "problem",
+            "name" : "Duplication in regular expression character class",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/regex/incomplete-special-group",
+          "name" : "py/regex/incomplete-special-group",
+          "shortDescription" : {
+            "text" : "Missing part of special group in regular expression"
+          },
+          "fullDescription" : {
+            "text" : "Incomplete special groups are parsed as normal groups and are unlikely to match the intended strings."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "Incomplete special groups are parsed as normal groups and are unlikely to match the intended strings.",
+            "id" : "py/regex/incomplete-special-group",
+            "kind" : "problem",
+            "name" : "Missing part of special group in regular expression",
+            "precision" : "high",
+            "problem.severity" : "warning",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/regex/unmatchable-caret",
+          "name" : "py/regex/unmatchable-caret",
+          "shortDescription" : {
+            "text" : "Unmatchable caret in regular expression"
+          },
+          "fullDescription" : {
+            "text" : "Regular expressions containing a caret '^' in the middle cannot be matched, whatever the input."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "Regular expressions containing a caret '^' in the middle cannot be matched, whatever the input.",
+            "id" : "py/regex/unmatchable-caret",
+            "kind" : "problem",
+            "name" : "Unmatchable caret in regular expression",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/regex/unmatchable-dollar",
+          "name" : "py/regex/unmatchable-dollar",
+          "shortDescription" : {
+            "text" : "Unmatchable dollar in regular expression"
+          },
+          "fullDescription" : {
+            "text" : "Regular expressions containing a dollar '$' in the middle cannot be matched, whatever the input."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "Regular expressions containing a dollar '$' in the middle cannot be matched, whatever the input.",
+            "id" : "py/regex/unmatchable-dollar",
+            "kind" : "problem",
+            "name" : "Unmatchable dollar in regular expression",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/truncated-division",
+          "name" : "py/truncated-division",
+          "shortDescription" : {
+            "text" : "Result of integer division may be truncated"
+          },
+          "fullDescription" : {
+            "text" : "The arguments to a division statement may be integers, which may cause the result to be truncated in Python 2."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "correctness" ],
+            "description" : "The arguments to a division statement may be integers, which\n              may cause the result to be truncated in Python 2.",
+            "id" : "py/truncated-division",
+            "kind" : "problem",
+            "name" : "Result of integer division may be truncated",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/implicit-string-concatenation-in-list",
+          "name" : "py/implicit-string-concatenation-in-list",
+          "shortDescription" : {
+            "text" : "Implicit string concatenation in a list"
+          },
+          "fullDescription" : {
+            "text" : "Omitting a comma between strings causes implicit concatenation which is confusing in a list."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "maintainability", "convention", "external/cwe/cwe-665" ],
+            "description" : "Omitting a comma between strings causes implicit concatenation which is confusing in a list.",
+            "id" : "py/implicit-string-concatenation-in-list",
+            "kind" : "problem",
+            "name" : "Implicit string concatenation in a list",
+            "precision" : "high",
+            "problem.severity" : "warning",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/unnecessary-lambda",
+          "name" : "py/unnecessary-lambda",
+          "shortDescription" : {
+            "text" : "Unnecessary lambda"
+          },
+          "fullDescription" : {
+            "text" : "A lambda is used that calls through to a function without modifying any parameters"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "useless-code" ],
+            "description" : "A lambda is used that calls through to a function without modifying any parameters",
+            "id" : "py/unnecessary-lambda",
+            "kind" : "problem",
+            "name" : "Unnecessary lambda",
+            "precision" : "high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/percent-format/unsupported-character",
+          "name" : "py/percent-format/unsupported-character",
+          "shortDescription" : {
+            "text" : "Unsupported format character"
+          },
+          "fullDescription" : {
+            "text" : "An unsupported format character in a format string"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "An unsupported format character in a format string",
+            "id" : "py/percent-format/unsupported-character",
+            "kind" : "problem",
+            "name" : "Unsupported format character",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/use-of-apply",
+          "name" : "py/use-of-apply",
+          "shortDescription" : {
+            "text" : "'apply' function used"
+          },
+          "fullDescription" : {
+            "text" : "The builtin function 'apply' is obsolete and should not be used."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "maintainability" ],
+            "description" : "The builtin function 'apply' is obsolete and should not be used.",
+            "id" : "py/use-of-apply",
+            "kind" : "problem",
+            "name" : "'apply' function used",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/use-of-input",
+          "name" : "py/use-of-input",
+          "shortDescription" : {
+            "text" : "'input' function used in Python 2"
+          },
+          "fullDescription" : {
+            "text" : "The built-in function 'input' is used which, in Python 2, can allow arbitrary code to be run."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "correctness", "security/cwe/cwe-94", "security/cwe/cwe-95" ],
+            "description" : "The built-in function 'input' is used which, in Python 2, can allow arbitrary code to be run.",
+            "id" : "py/use-of-input",
+            "kind" : "problem",
+            "name" : "'input' function used in Python 2",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.8",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/call/wrong-named-argument",
+          "name" : "py/call/wrong-named-argument",
+          "shortDescription" : {
+            "text" : "Wrong name for an argument in a call"
+          },
+          "fullDescription" : {
+            "text" : "Using a named argument whose name does not correspond to a parameter of the called function or method, will result in a TypeError at runtime."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness", "external/cwe/cwe-628" ],
+            "description" : "Using a named argument whose name does not correspond to a\n              parameter of the called function or method, will result in a\n              TypeError at runtime.",
+            "id" : "py/call/wrong-named-argument",
+            "kind" : "problem",
+            "name" : "Wrong name for an argument in a call",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/percent-format/wrong-arguments",
+          "name" : "py/percent-format/wrong-arguments",
+          "shortDescription" : {
+            "text" : "Wrong number of arguments for format"
+          },
+          "fullDescription" : {
+            "text" : "A string formatting operation, such as '\"%s: %s, %s\" % (a,b)', where the number of conversion specifiers in the format string differs from the number of values to be formatted will raise a TypeError."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness", "external/cwe/cwe-685" ],
+            "description" : "A string formatting operation, such as '\"%s: %s, %s\" % (a,b)', where the number of conversion specifiers in the\n              format string differs from the number of values to be formatted will raise a TypeError.",
+            "id" : "py/percent-format/wrong-arguments",
+            "kind" : "problem",
+            "name" : "Wrong number of arguments for format",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/call/wrong-arguments",
+          "name" : "py/call/wrong-arguments",
+          "shortDescription" : {
+            "text" : "Wrong number of arguments in a call"
+          },
+          "fullDescription" : {
+            "text" : "Using too many or too few arguments in a call to a function will result in a TypeError at runtime."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness", "external/cwe/cwe-685" ],
+            "description" : "Using too many or too few arguments in a call to a function will result in a TypeError at runtime.",
+            "id" : "py/call/wrong-arguments",
+            "kind" : "problem",
+            "name" : "Wrong number of arguments in a call",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/mixed-returns",
+          "name" : "py/mixed-returns",
+          "shortDescription" : {
+            "text" : "Explicit returns mixed with implicit (fall through) returns"
+          },
+          "fullDescription" : {
+            "text" : "Mixing implicit and explicit returns indicates a likely error as implicit returns always return 'None'."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "maintainability" ],
+            "description" : "Mixing implicit and explicit returns indicates a likely error as implicit returns always return 'None'.",
+            "id" : "py/mixed-returns",
+            "kind" : "problem",
+            "name" : "Explicit returns mixed with implicit (fall through) returns",
+            "precision" : "high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/deprecated-slice-method",
+          "name" : "py/deprecated-slice-method",
+          "shortDescription" : {
+            "text" : "Deprecated slice method"
+          },
+          "fullDescription" : {
+            "text" : "Defining special methods for slicing has been deprecated since Python 2.0."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "maintainability" ],
+            "description" : "Defining special methods for slicing has been deprecated since Python 2.0.",
+            "id" : "py/deprecated-slice-method",
+            "kind" : "problem",
+            "name" : "Deprecated slice method",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/explicit-return-in-init",
+          "name" : "py/explicit-return-in-init",
+          "shortDescription" : {
+            "text" : "`__init__` method returns a value"
+          },
+          "fullDescription" : {
+            "text" : "Explicitly returning a value from an `__init__` method will raise a TypeError."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "Explicitly returning a value from an `__init__` method will raise a TypeError.",
+            "id" : "py/explicit-return-in-init",
+            "kind" : "problem",
+            "name" : "`__init__` method returns a value",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/unexpected-raise-in-special-method",
+          "name" : "py/unexpected-raise-in-special-method",
+          "shortDescription" : {
+            "text" : "Non-standard exception raised in special method"
+          },
+          "fullDescription" : {
+            "text" : "Raising a non-standard exception in a special method alters the expected interface of that method."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "maintainability", "convention" ],
+            "description" : "Raising a non-standard exception in a special method alters the expected interface of that method.",
+            "id" : "py/unexpected-raise-in-special-method",
+            "kind" : "problem",
+            "name" : "Non-standard exception raised in special method",
+            "precision" : "very-high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/inheritance/incorrect-overriding-signature",
+          "name" : "py/inheritance/incorrect-overriding-signature",
+          "shortDescription" : {
+            "text" : "Mismatch between signature and use of an overriding method"
+          },
+          "fullDescription" : {
+            "text" : "Method has a different signature from the overridden method and, if it were called, would be likely to cause an error."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "maintainability" ],
+            "description" : "Method has a different signature from the overridden method and, if it were called, would be likely to cause an error.",
+            "id" : "py/inheritance/incorrect-overriding-signature",
+            "kind" : "problem",
+            "name" : "Mismatch between signature and use of an overriding method",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/inheritance/incorrect-overridden-signature",
+          "name" : "py/inheritance/incorrect-overridden-signature",
+          "shortDescription" : {
+            "text" : "Mismatch between signature and use of an overridden method"
+          },
+          "fullDescription" : {
+            "text" : "Method has a signature that differs from both the signature of its overriding methods and the arguments with which it is called, and if it were called, would be likely to cause an error."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "maintainability" ],
+            "description" : "Method has a signature that differs from both the signature of its overriding methods and\n              the arguments with which it is called, and if it were called, would be likely to cause an error.",
+            "id" : "py/inheritance/incorrect-overridden-signature",
+            "kind" : "problem",
+            "name" : "Mismatch between signature and use of an overridden method",
+            "precision" : "high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/init-method-is-generator",
+          "name" : "py/init-method-is-generator",
+          "shortDescription" : {
+            "text" : "`__init__` method is a generator"
+          },
+          "fullDescription" : {
+            "text" : "`__init__` method is a generator."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "`__init__` method is a generator.",
+            "id" : "py/init-method-is-generator",
+            "kind" : "problem",
+            "name" : "`__init__` method is a generator",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/iter-returns-non-iterator",
+          "name" : "py/iter-returns-non-iterator",
+          "shortDescription" : {
+            "text" : "`__iter__` method returns a non-iterator"
+          },
+          "fullDescription" : {
+            "text" : "The `__iter__` method returns a non-iterator which, if used in a 'for' loop, would raise a 'TypeError'."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "The `__iter__` method returns a non-iterator which, if used in a 'for' loop, would raise a 'TypeError'.",
+            "id" : "py/iter-returns-non-iterator",
+            "kind" : "problem",
+            "name" : "`__iter__` method returns a non-iterator",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/iter-returns-non-self",
+          "name" : "py/iter-returns-non-self",
+          "shortDescription" : {
+            "text" : "Iterator does not return self from `__iter__` method"
+          },
+          "fullDescription" : {
+            "text" : "Iterator does not return self from `__iter__` method, violating the iterator protocol."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "Iterator does not return self from `__iter__` method, violating the iterator protocol.",
+            "id" : "py/iter-returns-non-self",
+            "kind" : "problem",
+            "name" : "Iterator does not return self from `__iter__` method",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/modification-of-default-value",
+          "name" : "py/modification-of-default-value",
+          "shortDescription" : {
+            "text" : "Modification of parameter with default"
+          },
+          "fullDescription" : {
+            "text" : "Modifying the default value of a parameter can lead to unexpected results."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "maintainability" ],
+            "description" : "Modifying the default value of a parameter can lead to unexpected\n              results.",
+            "id" : "py/modification-of-default-value",
+            "kind" : "path-problem",
+            "name" : "Modification of parameter with default",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/not-named-cls",
+          "name" : "py/not-named-cls",
+          "shortDescription" : {
+            "text" : "First parameter of a class method is not named 'cls'"
+          },
+          "fullDescription" : {
+            "text" : "Using an alternative name for the first parameter of a class method makes code more difficult to read; PEP8 states that the first parameter to class methods should be 'cls'."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "readability", "convention" ],
+            "description" : "Using an alternative name for the first parameter of a class method makes code more\n              difficult to read; PEP8 states that the first parameter to class methods should be 'cls'.",
+            "id" : "py/not-named-cls",
+            "kind" : "problem",
+            "name" : "First parameter of a class method is not named 'cls'",
+            "precision" : "high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/not-named-self",
+          "name" : "py/not-named-self",
+          "shortDescription" : {
+            "text" : "First parameter of a method is not named 'self'"
+          },
+          "fullDescription" : {
+            "text" : "Using an alternative name for the first parameter of an instance method makes code more difficult to read; PEP8 states that the first parameter to instance methods should be 'self'."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "readability", "convention" ],
+            "description" : "Using an alternative name for the first parameter of an instance method makes\n              code more difficult to read; PEP8 states that the first parameter to instance\n              methods should be 'self'.",
+            "id" : "py/not-named-self",
+            "kind" : "problem",
+            "name" : "First parameter of a method is not named 'self'",
+            "precision" : "very-high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/overly-complex-delete",
+          "name" : "py/overly-complex-delete",
+          "shortDescription" : {
+            "text" : "Overly complex `__del__` method"
+          },
+          "fullDescription" : {
+            "text" : "`__del__` methods may be called at arbitrary times, perhaps never called at all, and should be simple."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "efficiency", "maintainability", "complexity", "statistical", "non-attributable" ],
+            "description" : "`__del__` methods may be called at arbitrary times, perhaps never called at all, and should be simple.",
+            "id" : "py/overly-complex-delete",
+            "kind" : "problem",
+            "name" : "Overly complex `__del__` method",
+            "precision" : "high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/mixed-tuple-returns",
+          "name" : "py/mixed-tuple-returns",
+          "shortDescription" : {
+            "text" : "Returning tuples with varying lengths"
+          },
+          "fullDescription" : {
+            "text" : "A function that potentially returns tuples of different lengths may indicate a problem."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "maintainability" ],
+            "description" : "A function that potentially returns tuples of different lengths may indicate a problem.",
+            "id" : "py/mixed-tuple-returns",
+            "kind" : "problem",
+            "name" : "Returning tuples with varying lengths",
+            "precision" : "high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/inheritance/signature-mismatch",
+          "name" : "py/inheritance/signature-mismatch",
+          "shortDescription" : {
+            "text" : "Signature mismatch in overriding method"
+          },
+          "fullDescription" : {
+            "text" : "Overriding a method without ensuring that both methods accept the same number and type of parameters has the potential to cause an error when there is a mismatch."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "Overriding a method without ensuring that both methods accept the same\n              number and type of parameters has the potential to cause an error when there is a mismatch.",
+            "id" : "py/inheritance/signature-mismatch",
+            "kind" : "problem",
+            "name" : "Signature mismatch in overriding method",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/special-method-wrong-signature",
+          "name" : "py/special-method-wrong-signature",
+          "shortDescription" : {
+            "text" : "Special method has incorrect signature"
+          },
+          "fullDescription" : {
+            "text" : "Special method has incorrect signature"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "Special method has incorrect signature",
+            "id" : "py/special-method-wrong-signature",
+            "kind" : "problem",
+            "name" : "Special method has incorrect signature",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/procedure-return-value-used",
+          "name" : "py/procedure-return-value-used",
+          "shortDescription" : {
+            "text" : "Use of the return value of a procedure"
+          },
+          "fullDescription" : {
+            "text" : "The return value of a procedure (a function that does not return a value) is used. This is confusing to the reader as the value (None) has no meaning."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "maintainability" ],
+            "description" : "The return value of a procedure (a function that does not return a value) is used. This is confusing to the reader as the value (None) has no meaning.",
+            "id" : "py/procedure-return-value-used",
+            "kind" : "problem",
+            "name" : "Use of the return value of a procedure",
+            "precision" : "high",
+            "problem.severity" : "warning",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/cyclic-import",
+          "name" : "py/cyclic-import",
+          "shortDescription" : {
+            "text" : "Cyclic import"
+          },
+          "fullDescription" : {
+            "text" : "Module forms part of an import cycle, thereby indirectly importing itself."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "maintainability", "modularity" ],
+            "description" : "Module forms part of an import cycle, thereby indirectly importing itself.",
+            "id" : "py/cyclic-import",
+            "kind" : "problem",
+            "name" : "Cyclic import",
+            "precision" : "high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/import-deprecated-module",
+          "name" : "py/import-deprecated-module",
+          "shortDescription" : {
+            "text" : "Import of deprecated module"
+          },
+          "fullDescription" : {
+            "text" : "Import of a deprecated module"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "external/cwe/cwe-477" ],
+            "description" : "Import of a deprecated module",
+            "id" : "py/import-deprecated-module",
+            "kind" : "problem",
+            "name" : "Import of deprecated module",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/encoding-error",
+          "name" : "py/encoding-error",
+          "shortDescription" : {
+            "text" : "Encoding error"
+          },
+          "fullDescription" : {
+            "text" : "Encoding errors cause failures at runtime and prevent analysis of the code."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "Encoding errors cause failures at runtime and prevent analysis of the code.",
+            "id" : "py/encoding-error",
+            "kind" : "problem",
+            "name" : "Encoding error",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/import-and-import-from",
+          "name" : "py/import-and-import-from",
+          "shortDescription" : {
+            "text" : "Module is imported with 'import' and 'import from'"
+          },
+          "fullDescription" : {
+            "text" : "A module is imported with the \"import\" and \"import from\" statements"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "maintainability" ],
+            "description" : "A module is imported with the \"import\" and \"import from\" statements",
+            "id" : "py/import-and-import-from",
+            "kind" : "problem",
+            "name" : "Module is imported with 'import' and 'import from'",
+            "precision" : "very-high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/import-own-module",
+          "name" : "py/import-own-module",
+          "shortDescription" : {
+            "text" : "Module imports itself"
+          },
+          "fullDescription" : {
+            "text" : "A module imports itself"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "useless-code" ],
+            "description" : "A module imports itself",
+            "id" : "py/import-own-module",
+            "kind" : "problem",
+            "name" : "Module imports itself",
+            "precision" : "very-high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/unsafe-cyclic-import",
+          "name" : "py/unsafe-cyclic-import",
+          "shortDescription" : {
+            "text" : "Module-level cyclic import"
+          },
+          "fullDescription" : {
+            "text" : "Module uses member of cyclically imported module, which can lead to failure at import time."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness", "types" ],
+            "comprehension" : "0.5",
+            "description" : "Module uses member of cyclically imported module, which can lead to failure at import time.",
+            "id" : "py/unsafe-cyclic-import",
+            "kind" : "problem",
+            "name" : "Module-level cyclic import",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/repeated-import",
+          "name" : "py/repeated-import",
+          "shortDescription" : {
+            "text" : "Module is imported more than once"
+          },
+          "fullDescription" : {
+            "text" : "Importing a module a second time has no effect and impairs readability"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "useless-code" ],
+            "description" : "Importing a module a second time has no effect and impairs readability",
+            "id" : "py/repeated-import",
+            "kind" : "problem",
+            "name" : "Module is imported more than once",
+            "precision" : "very-high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/syntax-error",
+          "name" : "py/syntax-error",
+          "shortDescription" : {
+            "text" : "Syntax error"
+          },
+          "fullDescription" : {
+            "text" : "Syntax errors cause failures at runtime and prevent analysis of the code."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "Syntax errors cause failures at runtime and prevent analysis of the code.",
+            "id" : "py/syntax-error",
+            "kind" : "problem",
+            "name" : "Syntax error",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/polluting-import",
+          "name" : "py/polluting-import",
+          "shortDescription" : {
+            "text" : "'import *' may pollute namespace"
+          },
+          "fullDescription" : {
+            "text" : "Importing a module using 'import *' may unintentionally pollute the global namespace if the module does not define `__all__`"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "modularity" ],
+            "description" : "Importing a module using 'import *' may unintentionally pollute the global\n              namespace if the module does not define `__all__`",
+            "id" : "py/polluting-import",
+            "kind" : "problem",
+            "name" : "'import *' may pollute namespace",
+            "precision" : "very-high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/unused-import",
+          "name" : "py/unused-import",
+          "shortDescription" : {
+            "text" : "Unused import"
+          },
+          "fullDescription" : {
+            "text" : "Import is not required as it is not used"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "useless-code" ],
+            "description" : "Import is not required as it is not used",
+            "id" : "py/unused-import",
+            "kind" : "problem",
+            "name" : "Unused import",
+            "precision" : "very-high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/commented-out-code",
+          "name" : "py/commented-out-code",
+          "shortDescription" : {
+            "text" : "Commented-out code"
+          },
+          "fullDescription" : {
+            "text" : "Commented-out code makes the remaining code more difficult to read."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "readability", "documentation" ],
+            "description" : "Commented-out code makes the remaining code more difficult to read.",
+            "id" : "py/commented-out-code",
+            "kind" : "problem",
+            "name" : "Commented-out code",
+            "precision" : "high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/old-style-octal-literal",
+          "name" : "py/old-style-octal-literal",
+          "shortDescription" : {
+            "text" : "Confusing octal literal"
+          },
+          "fullDescription" : {
+            "text" : "Octal literal with a leading 0 is easily misread as a decimal value"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "readability" ],
+            "description" : "Octal literal with a leading 0 is easily misread as a decimal value",
+            "id" : "py/old-style-octal-literal",
+            "kind" : "problem",
+            "name" : "Confusing octal literal",
+            "precision" : "high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/bind-socket-all-network-interfaces",
+          "name" : "py/bind-socket-all-network-interfaces",
+          "shortDescription" : {
+            "text" : "Binding a socket to all network interfaces"
+          },
+          "fullDescription" : {
+            "text" : "Binding a socket to all interfaces opens it up to traffic from any IPv4 address and is therefore associated with security risks."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-200" ],
+            "description" : "Binding a socket to all interfaces opens it up to traffic from any IPv4 address\n and is therefore associated with security risks.",
+            "id" : "py/bind-socket-all-network-interfaces",
+            "kind" : "problem",
+            "name" : "Binding a socket to all network interfaces",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "6.5",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/incomplete-hostname-regexp",
+          "name" : "py/incomplete-hostname-regexp",
+          "shortDescription" : {
+            "text" : "Incomplete regular expression for hostnames"
+          },
+          "fullDescription" : {
+            "text" : "Matching a URL or hostname against a regular expression that contains an unescaped dot as part of the hostname might match more hostnames than expected."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "correctness", "security", "external/cwe/cwe-020" ],
+            "description" : "Matching a URL or hostname against a regular expression that contains an unescaped dot as part of the hostname might match more hostnames than expected.",
+            "id" : "py/incomplete-hostname-regexp",
+            "kind" : "problem",
+            "name" : "Incomplete regular expression for hostnames",
+            "precision" : "high",
+            "problem.severity" : "warning",
+            "security-severity" : "7.8"
+          }
+        }, {
+          "id" : "py/incomplete-url-substring-sanitization",
+          "name" : "py/incomplete-url-substring-sanitization",
+          "shortDescription" : {
+            "text" : "Incomplete URL substring sanitization"
+          },
+          "fullDescription" : {
+            "text" : "Security checks on the substrings of an unparsed URL are often vulnerable to bypassing."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "correctness", "security", "external/cwe/cwe-20" ],
+            "description" : "Security checks on the substrings of an unparsed URL are often vulnerable to bypassing.",
+            "id" : "py/incomplete-url-substring-sanitization",
+            "kind" : "problem",
+            "name" : "Incomplete URL substring sanitization",
+            "precision" : "high",
+            "problem.severity" : "warning",
+            "security-severity" : "7.8"
+          }
+        }, {
+          "id" : "py/path-injection",
+          "name" : "py/path-injection",
+          "shortDescription" : {
+            "text" : "Uncontrolled data used in path expression"
+          },
+          "fullDescription" : {
+            "text" : "Accessing paths influenced by users can allow an attacker to access unexpected resources."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "correctness", "security", "external/cwe/cwe-022", "external/cwe/cwe-023", "external/cwe/cwe-036", "external/cwe/cwe-073", "external/cwe/cwe-099" ],
+            "description" : "Accessing paths influenced by users can allow an attacker to access unexpected resources.",
+            "id" : "py/path-injection",
+            "kind" : "path-problem",
+            "name" : "Uncontrolled data used in path expression",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "7.5",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/command-line-injection",
+          "name" : "py/command-line-injection",
+          "shortDescription" : {
+            "text" : "Uncontrolled command line"
+          },
+          "fullDescription" : {
+            "text" : "Using externally controlled strings in a command line may allow a malicious user to change the meaning of the command."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "correctness", "security", "external/cwe/cwe-078", "external/cwe/cwe-088" ],
+            "description" : "Using externally controlled strings in a command line may allow a malicious\n              user to change the meaning of the command.",
+            "id" : "py/command-line-injection",
+            "kind" : "path-problem",
+            "name" : "Uncontrolled command line",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.8",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/reflective-xss",
+          "name" : "py/reflective-xss",
+          "shortDescription" : {
+            "text" : "Reflected server-side cross-site scripting"
+          },
+          "fullDescription" : {
+            "text" : "Writing user input directly to a web page allows for a cross-site scripting vulnerability."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-079", "external/cwe/cwe-116" ],
+            "description" : "Writing user input directly to a web page\n              allows for a cross-site scripting vulnerability.",
+            "id" : "py/reflective-xss",
+            "kind" : "path-problem",
+            "name" : "Reflected server-side cross-site scripting",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "6.1",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/sql-injection",
+          "name" : "py/sql-injection",
+          "shortDescription" : {
+            "text" : "SQL query built from user-controlled sources"
+          },
+          "fullDescription" : {
+            "text" : "Building a SQL query from user-controlled sources is vulnerable to insertion of malicious SQL code by the user."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-089" ],
+            "description" : "Building a SQL query from user-controlled sources is vulnerable to insertion of\n              malicious SQL code by the user.",
+            "id" : "py/sql-injection",
+            "kind" : "path-problem",
+            "name" : "SQL query built from user-controlled sources",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "8.8"
+          }
+        }, {
+          "id" : "py/ldap-injection",
+          "name" : "py/ldap-injection",
+          "shortDescription" : {
+            "text" : "LDAP query built from user-controlled sources"
+          },
+          "fullDescription" : {
+            "text" : "Building an LDAP query from user-controlled sources is vulnerable to insertion of malicious LDAP code by the user."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-090" ],
+            "description" : "Building an LDAP query from user-controlled sources is vulnerable to insertion of\n              malicious LDAP code by the user.",
+            "id" : "py/ldap-injection",
+            "kind" : "path-problem",
+            "name" : "LDAP query built from user-controlled sources",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.8"
+          }
+        }, {
+          "id" : "py/code-injection",
+          "name" : "py/code-injection",
+          "shortDescription" : {
+            "text" : "Code injection"
+          },
+          "fullDescription" : {
+            "text" : "Interpreting unsanitized user input as code allows a malicious user to perform arbitrary code execution."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-094", "external/cwe/cwe-095", "external/cwe/cwe-116" ],
+            "description" : "Interpreting unsanitized user input as code allows a malicious user to perform arbitrary\n              code execution.",
+            "id" : "py/code-injection",
+            "kind" : "path-problem",
+            "name" : "Code injection",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.3",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/bad-tag-filter",
+          "name" : "py/bad-tag-filter",
+          "shortDescription" : {
+            "text" : "Bad HTML filtering regexp"
+          },
+          "fullDescription" : {
+            "text" : "Matching HTML tags using regular expressions is hard to do right, and can easily lead to security issues."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "correctness", "security", "external/cwe/cwe-116", "external/cwe/cwe-020", "external/cwe/cwe-185", "external/cwe/cwe-186" ],
+            "description" : "Matching HTML tags using regular expressions is hard to do right, and can easily lead to security issues.",
+            "id" : "py/bad-tag-filter",
+            "kind" : "problem",
+            "name" : "Bad HTML filtering regexp",
+            "precision" : "high",
+            "problem.severity" : "warning",
+            "security-severity" : "7.8"
+          }
+        }, {
+          "id" : "py/stack-trace-exposure",
+          "name" : "py/stack-trace-exposure",
+          "shortDescription" : {
+            "text" : "Information exposure through an exception"
+          },
+          "fullDescription" : {
+            "text" : "Leaking information about an exception, such as messages and stack traces, to an external user can expose implementation details that are useful to an attacker for developing a subsequent exploit."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-209", "external/cwe/cwe-497" ],
+            "description" : "Leaking information about an exception, such as messages and stack traces, to an\n              external user can expose implementation details that are useful to an attacker for\n              developing a subsequent exploit.",
+            "id" : "py/stack-trace-exposure",
+            "kind" : "path-problem",
+            "name" : "Information exposure through an exception",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "5.4"
+          }
+        }, {
+          "id" : "py/flask-debug",
+          "name" : "py/flask-debug",
+          "shortDescription" : {
+            "text" : "Flask app is run in debug mode"
+          },
+          "fullDescription" : {
+            "text" : "Running a Flask app in debug mode may allow an attacker to run arbitrary code through the Werkzeug debugger."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-215", "external/cwe/cwe-489" ],
+            "description" : "Running a Flask app in debug mode may allow an attacker to run arbitrary code through the Werkzeug debugger.",
+            "id" : "py/flask-debug",
+            "kind" : "problem",
+            "name" : "Flask app is run in debug mode",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "7.5"
+          }
+        }, {
+          "id" : "py/pam-auth-bypass",
+          "name" : "py/pam-auth-bypass",
+          "shortDescription" : {
+            "text" : "PAM authorization bypass due to incorrect usage"
+          },
+          "fullDescription" : {
+            "text" : "Not using `pam_acct_mgmt` after `pam_authenticate` to check the validity of a login can lead to authorization bypass."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-285" ],
+            "description" : "Not using `pam_acct_mgmt` after `pam_authenticate` to check the validity of a login can lead to authorization bypass.",
+            "id" : "py/pam-auth-bypass",
+            "kind" : "problem",
+            "name" : "PAM authorization bypass due to incorrect usage",
+            "precision" : "high",
+            "problem.severity" : "warning",
+            "security-severity" : "8.1"
+          }
+        }, {
+          "id" : "py/paramiko-missing-host-key-validation",
+          "name" : "py/paramiko-missing-host-key-validation",
+          "shortDescription" : {
+            "text" : "Accepting unknown SSH host keys when using Paramiko"
+          },
+          "fullDescription" : {
+            "text" : "Accepting unknown host keys can allow man-in-the-middle attacks."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-295" ],
+            "description" : "Accepting unknown host keys can allow man-in-the-middle attacks.",
+            "id" : "py/paramiko-missing-host-key-validation",
+            "kind" : "problem",
+            "name" : "Accepting unknown SSH host keys when using Paramiko",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "7.5"
+          }
+        }, {
+          "id" : "py/clear-text-logging-sensitive-data",
+          "name" : "py/clear-text-logging-sensitive-data",
+          "shortDescription" : {
+            "text" : "Clear-text logging of sensitive information"
+          },
+          "fullDescription" : {
+            "text" : "Logging sensitive information without encryption or hashing can expose it to an attacker."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-312", "external/cwe/cwe-359", "external/cwe/cwe-532" ],
+            "description" : "Logging sensitive information without encryption or hashing can\n              expose it to an attacker.",
+            "id" : "py/clear-text-logging-sensitive-data",
+            "kind" : "path-problem",
+            "name" : "Clear-text logging of sensitive information",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "7.5"
+          }
+        }, {
+          "id" : "py/clear-text-storage-sensitive-data",
+          "name" : "py/clear-text-storage-sensitive-data",
+          "shortDescription" : {
+            "text" : "Clear-text storage of sensitive information"
+          },
+          "fullDescription" : {
+            "text" : "Sensitive information stored without encryption or hashing can expose it to an attacker."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-312", "external/cwe/cwe-315", "external/cwe/cwe-359" ],
+            "description" : "Sensitive information stored without encryption or hashing can expose it to an\n              attacker.",
+            "id" : "py/clear-text-storage-sensitive-data",
+            "kind" : "path-problem",
+            "name" : "Clear-text storage of sensitive information",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "7.5"
+          }
+        }, {
+          "id" : "py/weak-crypto-key",
+          "name" : "py/weak-crypto-key",
+          "shortDescription" : {
+            "text" : "Use of weak cryptographic key"
+          },
+          "fullDescription" : {
+            "text" : "Use of a cryptographic key that is too small may allow the encryption to be broken."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-326" ],
+            "description" : "Use of a cryptographic key that is too small may allow the encryption to be broken.",
+            "id" : "py/weak-crypto-key",
+            "kind" : "problem",
+            "name" : "Use of weak cryptographic key",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "7.5"
+          }
+        }, {
+          "id" : "py/weak-cryptographic-algorithm",
+          "name" : "py/weak-cryptographic-algorithm",
+          "shortDescription" : {
+            "text" : "Use of a broken or weak cryptographic algorithm"
+          },
+          "fullDescription" : {
+            "text" : "Using broken or weak cryptographic algorithms can compromise security."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-327" ],
+            "description" : "Using broken or weak cryptographic algorithms can compromise security.",
+            "id" : "py/weak-cryptographic-algorithm",
+            "kind" : "problem",
+            "name" : "Use of a broken or weak cryptographic algorithm",
+            "precision" : "high",
+            "problem.severity" : "warning",
+            "security-severity" : "7.5"
+          }
+        }, {
+          "id" : "py/insecure-default-protocol",
+          "name" : "py/insecure-default-protocol",
+          "shortDescription" : {
+            "text" : "Default version of SSL/TLS may be insecure"
+          },
+          "fullDescription" : {
+            "text" : "Leaving the SSL/TLS version unspecified may result in an insecure default protocol being used."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-327" ],
+            "description" : "Leaving the SSL/TLS version unspecified may result in an insecure\n              default protocol being used.",
+            "id" : "py/insecure-default-protocol",
+            "kind" : "problem",
+            "name" : "Default version of SSL/TLS may be insecure",
+            "precision" : "high",
+            "problem.severity" : "warning",
+            "security-severity" : "7.5"
+          }
+        }, {
+          "id" : "py/insecure-protocol",
+          "name" : "py/insecure-protocol",
+          "shortDescription" : {
+            "text" : "Use of insecure SSL/TLS version"
+          },
+          "fullDescription" : {
+            "text" : "Using an insecure SSL/TLS version may leave the connection vulnerable to attacks."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-327" ],
+            "description" : "Using an insecure SSL/TLS version may leave the connection vulnerable to attacks.",
+            "id" : "py/insecure-protocol",
+            "kind" : "problem",
+            "name" : "Use of insecure SSL/TLS version",
+            "precision" : "high",
+            "problem.severity" : "warning",
+            "security-severity" : "7.5"
+          }
+        }, {
+          "id" : "py/weak-sensitive-data-hashing",
+          "name" : "py/weak-sensitive-data-hashing",
+          "shortDescription" : {
+            "text" : "Use of a broken or weak cryptographic hashing algorithm on sensitive data"
+          },
+          "fullDescription" : {
+            "text" : "Using broken or weak cryptographic hashing algorithms can compromise security."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-327", "external/cwe/cwe-328", "external/cwe/cwe-916" ],
+            "description" : "Using broken or weak cryptographic hashing algorithms can compromise security.",
+            "id" : "py/weak-sensitive-data-hashing",
+            "kind" : "path-problem",
+            "name" : "Use of a broken or weak cryptographic hashing algorithm on sensitive data",
+            "precision" : "high",
+            "problem.severity" : "warning",
+            "security-severity" : "7.5"
+          }
+        }, {
+          "id" : "py/csrf-protection-disabled",
+          "name" : "py/csrf-protection-disabled",
+          "shortDescription" : {
+            "text" : "CSRF protection weakened or disabled"
+          },
+          "fullDescription" : {
+            "text" : "Disabling or weakening CSRF protection may make the application vulnerable to a Cross-Site Request Forgery (CSRF) attack."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-352" ],
+            "description" : "Disabling or weakening CSRF protection may make the application\n              vulnerable to a Cross-Site Request Forgery (CSRF) attack.",
+            "id" : "py/csrf-protection-disabled",
+            "kind" : "problem",
+            "name" : "CSRF protection weakened or disabled",
+            "precision" : "high",
+            "problem.severity" : "warning",
+            "security-severity" : "8.8"
+          }
+        }, {
+          "id" : "py/insecure-temporary-file",
+          "name" : "py/insecure-temporary-file",
+          "shortDescription" : {
+            "text" : "Insecure temporary file"
+          },
+          "fullDescription" : {
+            "text" : "Creating a temporary file using this method may be insecure."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "external/cwe/cwe-377", "security" ],
+            "description" : "Creating a temporary file using this method may be insecure.",
+            "id" : "py/insecure-temporary-file",
+            "kind" : "problem",
+            "name" : "Insecure temporary file",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "7.0",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/unsafe-deserialization",
+          "name" : "py/unsafe-deserialization",
+          "shortDescription" : {
+            "text" : "Deserializing untrusted input"
+          },
+          "fullDescription" : {
+            "text" : "Deserializing user-controlled data may allow attackers to execute arbitrary code."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "external/cwe/cwe-502", "security", "serialization" ],
+            "description" : "Deserializing user-controlled data may allow attackers to execute arbitrary code.",
+            "id" : "py/unsafe-deserialization",
+            "kind" : "path-problem",
+            "name" : "Deserializing untrusted input",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.8",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/url-redirection",
+          "name" : "py/url-redirection",
+          "shortDescription" : {
+            "text" : "URL redirection from remote source"
+          },
+          "fullDescription" : {
+            "text" : "URL redirection based on unvalidated user input may cause redirection to malicious web sites."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-601" ],
+            "description" : "URL redirection based on unvalidated user input\n              may cause redirection to malicious web sites.",
+            "id" : "py/url-redirection",
+            "kind" : "path-problem",
+            "name" : "URL redirection from remote source",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "6.1",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/xxe",
+          "name" : "py/xxe",
+          "shortDescription" : {
+            "text" : "XML external entity expansion"
+          },
+          "fullDescription" : {
+            "text" : "Parsing user input as an XML document with external entity expansion is vulnerable to XXE attacks."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-611", "external/cwe/cwe-827" ],
+            "description" : "Parsing user input as an XML document with external\n              entity expansion is vulnerable to XXE attacks.",
+            "id" : "py/xxe",
+            "kind" : "path-problem",
+            "name" : "XML external entity expansion",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.1"
+          }
+        }, {
+          "id" : "py/xpath-injection",
+          "name" : "py/xpath-injection",
+          "shortDescription" : {
+            "text" : "XPath query built from user-controlled sources"
+          },
+          "fullDescription" : {
+            "text" : "Building a XPath query from user-controlled sources is vulnerable to insertion of malicious Xpath code by the user."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-643" ],
+            "description" : "Building a XPath query from user-controlled sources is vulnerable to insertion of\n              malicious Xpath code by the user.",
+            "id" : "py/xpath-injection",
+            "kind" : "path-problem",
+            "name" : "XPath query built from user-controlled sources",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.8"
+          }
+        }, {
+          "id" : "py/polynomial-redos",
+          "name" : "py/polynomial-redos",
+          "shortDescription" : {
+            "text" : "Polynomial regular expression used on uncontrolled data"
+          },
+          "fullDescription" : {
+            "text" : "A regular expression that can require polynomial time to match may be vulnerable to denial-of-service attacks."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-1333", "external/cwe/cwe-730", "external/cwe/cwe-400" ],
+            "description" : "A regular expression that can require polynomial time\n              to match may be vulnerable to denial-of-service attacks.",
+            "id" : "py/polynomial-redos",
+            "kind" : "path-problem",
+            "name" : "Polynomial regular expression used on uncontrolled data",
+            "precision" : "high",
+            "problem.severity" : "warning"
+          }
+        }, {
+          "id" : "py/redos",
+          "name" : "py/redos",
+          "shortDescription" : {
+            "text" : "Inefficient regular expression"
+          },
+          "fullDescription" : {
+            "text" : "A regular expression that requires exponential time to match certain inputs can be a performance bottleneck, and may be vulnerable to denial-of-service attacks."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-1333", "external/cwe/cwe-730", "external/cwe/cwe-400" ],
+            "description" : "A regular expression that requires exponential time to match certain inputs\n              can be a performance bottleneck, and may be vulnerable to denial-of-service\n              attacks.",
+            "id" : "py/redos",
+            "kind" : "problem",
+            "name" : "Inefficient regular expression",
+            "precision" : "high",
+            "problem.severity" : "error"
+          }
+        }, {
+          "id" : "py/regex-injection",
+          "name" : "py/regex-injection",
+          "shortDescription" : {
+            "text" : "Regular expression injection"
+          },
+          "fullDescription" : {
+            "text" : "User input should not be used in regular expressions without first being escaped, otherwise a malicious user may be able to inject an expression that could require exponential time on certain inputs."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-730", "external/cwe/cwe-400" ],
+            "description" : "User input should not be used in regular expressions without first being escaped,\n              otherwise a malicious user may be able to inject an expression that could require\n              exponential time on certain inputs.",
+            "id" : "py/regex-injection",
+            "kind" : "path-problem",
+            "name" : "Regular expression injection",
+            "precision" : "high",
+            "problem.severity" : "error"
+          }
+        }, {
+          "id" : "py/xml-bomb",
+          "name" : "py/xml-bomb",
+          "shortDescription" : {
+            "text" : "XML internal entity expansion"
+          },
+          "fullDescription" : {
+            "text" : "Parsing user input as an XML document with arbitrary internal entity expansion is vulnerable to denial-of-service attacks."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-776", "external/cwe/cwe-400" ],
+            "description" : "Parsing user input as an XML document with arbitrary internal\n              entity expansion is vulnerable to denial-of-service attacks.",
+            "id" : "py/xml-bomb",
+            "kind" : "path-problem",
+            "name" : "XML internal entity expansion",
+            "precision" : "high",
+            "problem.severity" : "warning",
+            "security-severity" : "7.5"
+          }
+        }, {
+          "id" : "py/full-ssrf",
+          "name" : "py/full-ssrf",
+          "shortDescription" : {
+            "text" : "Full server-side request forgery"
+          },
+          "fullDescription" : {
+            "text" : "Making a network request to a URL that is fully user-controlled allows for request forgery attacks."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-918" ],
+            "description" : "Making a network request to a URL that is fully user-controlled allows for request forgery attacks.",
+            "id" : "py/full-ssrf",
+            "kind" : "path-problem",
+            "name" : "Full server-side request forgery",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "security-severity" : "9.1"
+          }
+        }, {
+          "id" : "py/asserts-tuple",
+          "name" : "py/asserts-tuple",
+          "shortDescription" : {
+            "text" : "Asserting a tuple"
+          },
+          "fullDescription" : {
+            "text" : "Using an assert statement to test a tuple provides no validity checking."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "maintainability", "external/cwe/cwe-670" ],
+            "description" : "Using an assert statement to test a tuple provides no validity checking.",
+            "id" : "py/asserts-tuple",
+            "kind" : "problem",
+            "name" : "Asserting a tuple",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/constant-conditional-expression",
+          "name" : "py/constant-conditional-expression",
+          "shortDescription" : {
+            "text" : "Constant in conditional expression or statement"
+          },
+          "fullDescription" : {
+            "text" : "The conditional is always true or always false"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "useless-code", "external/cwe/cwe-561", "external/cwe/cwe-570", "external/cwe/cwe-571" ],
+            "description" : "The conditional is always true or always false",
+            "id" : "py/constant-conditional-expression",
+            "kind" : "problem",
+            "name" : "Constant in conditional expression or statement",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/iteration-string-and-sequence",
+          "name" : "py/iteration-string-and-sequence",
+          "shortDescription" : {
+            "text" : "Iterable can be either a string or a sequence"
+          },
+          "fullDescription" : {
+            "text" : "Iteration over either a string or a sequence in the same loop can cause errors that are hard to find."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "maintainability", "non-local" ],
+            "description" : "Iteration over either a string or a sequence in the same loop can cause errors that are hard to find.",
+            "id" : "py/iteration-string-and-sequence",
+            "kind" : "problem",
+            "name" : "Iterable can be either a string or a sequence",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/mismatched-multiple-assignment",
+          "name" : "py/mismatched-multiple-assignment",
+          "shortDescription" : {
+            "text" : "Mismatch in multiple assignment"
+          },
+          "fullDescription" : {
+            "text" : "Assigning multiple variables without ensuring that you define a value for each variable causes an exception at runtime."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness", "types" ],
+            "description" : "Assigning multiple variables without ensuring that you define a\n              value for each variable causes an exception at runtime.",
+            "id" : "py/mismatched-multiple-assignment",
+            "kind" : "problem",
+            "name" : "Mismatch in multiple assignment",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/modification-of-locals",
+          "name" : "py/modification-of-locals",
+          "shortDescription" : {
+            "text" : "Modification of dictionary returned by locals()"
+          },
+          "fullDescription" : {
+            "text" : "Modifications of the dictionary returned by locals() are not propagated to the local variables of a function."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "Modifications of the dictionary returned by locals() are not propagated to the local variables of a function.",
+            "id" : "py/modification-of-locals",
+            "kind" : "problem",
+            "name" : "Modification of dictionary returned by locals()",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/nested-loops-with-same-variable",
+          "name" : "py/nested-loops-with-same-variable",
+          "shortDescription" : {
+            "text" : "Nested loops with same variable"
+          },
+          "fullDescription" : {
+            "text" : "Nested loops in which the target variable is the same for each loop make the behavior of the loops difficult to understand."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "correctness" ],
+            "description" : "Nested loops in which the target variable is the same for each loop make\n              the behavior of the loops difficult to understand.",
+            "id" : "py/nested-loops-with-same-variable",
+            "kind" : "problem",
+            "name" : "Nested loops with same variable",
+            "precision" : "very-high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/nested-loops-with-same-variable-reused",
+          "name" : "py/nested-loops-with-same-variable-reused",
+          "shortDescription" : {
+            "text" : "Nested loops with same variable reused after inner loop body"
+          },
+          "fullDescription" : {
+            "text" : "Redefining a variable in an inner loop and then using the variable in an outer loop causes unexpected behavior."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "correctness" ],
+            "description" : "Redefining a variable in an inner loop and then using\n              the variable in an outer loop causes unexpected behavior.",
+            "id" : "py/nested-loops-with-same-variable-reused",
+            "kind" : "problem",
+            "name" : "Nested loops with same variable reused after inner loop body",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/non-iterable-in-for-loop",
+          "name" : "py/non-iterable-in-for-loop",
+          "shortDescription" : {
+            "text" : "Non-iterable used in for loop"
+          },
+          "fullDescription" : {
+            "text" : "Using a non-iterable as the object in a 'for' loop causes a TypeError."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness", "types" ],
+            "description" : "Using a non-iterable as the object in a 'for' loop causes a TypeError.",
+            "id" : "py/non-iterable-in-for-loop",
+            "kind" : "problem",
+            "name" : "Non-iterable used in for loop",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/redundant-assignment",
+          "name" : "py/redundant-assignment",
+          "shortDescription" : {
+            "text" : "Redundant assignment"
+          },
+          "fullDescription" : {
+            "text" : "Assigning a variable to itself is useless and very likely indicates an error in the code."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "useless-code", "external/cwe/cwe-563" ],
+            "description" : "Assigning a variable to itself is useless and very likely indicates an error in the code.",
+            "id" : "py/redundant-assignment",
+            "kind" : "problem",
+            "name" : "Redundant assignment",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/should-use-with",
+          "name" : "py/should-use-with",
+          "shortDescription" : {
+            "text" : "Should use a 'with' statement"
+          },
+          "fullDescription" : {
+            "text" : "Using a 'try-finally' block to ensure only that a resource is closed makes code more difficult to read."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "readability", "convention" ],
+            "description" : "Using a 'try-finally' block to ensure only that a resource is closed makes code more\n              difficult to read.",
+            "id" : "py/should-use-with",
+            "kind" : "problem",
+            "name" : "Should use a 'with' statement",
+            "precision" : "very-high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/side-effect-in-assert",
+          "name" : "py/side-effect-in-assert",
+          "shortDescription" : {
+            "text" : "An assert statement has a side-effect"
+          },
+          "fullDescription" : {
+            "text" : "Side-effects in assert statements result in differences between normal and optimized behavior."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "maintainability" ],
+            "description" : "Side-effects in assert statements result in differences between normal\n              and optimized behavior.",
+            "id" : "py/side-effect-in-assert",
+            "kind" : "problem",
+            "name" : "An assert statement has a side-effect",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/ineffectual-statement",
+          "name" : "py/ineffectual-statement",
+          "shortDescription" : {
+            "text" : "Statement has no effect"
+          },
+          "fullDescription" : {
+            "text" : "A statement has no effect"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "useless-code", "external/cwe/cwe-561" ],
+            "description" : "A statement has no effect",
+            "id" : "py/ineffectual-statement",
+            "kind" : "problem",
+            "name" : "Statement has no effect",
+            "precision" : "high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/print-during-import",
+          "name" : "py/print-during-import",
+          "shortDescription" : {
+            "text" : "Use of a print statement at module level"
+          },
+          "fullDescription" : {
+            "text" : "Using a print statement at module scope (except when guarded by `if __name__ == '__main__'`) will cause surprising output when the module is imported."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "maintainability", "convention" ],
+            "description" : "Using a print statement at module scope (except when guarded by `if __name__ == '__main__'`) will cause surprising output when the module is imported.",
+            "id" : "py/print-during-import",
+            "kind" : "problem",
+            "name" : "Use of a print statement at module level",
+            "precision" : "high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/unnecessary-delete",
+          "name" : "py/unnecessary-delete",
+          "shortDescription" : {
+            "text" : "Unnecessary delete statement in function"
+          },
+          "fullDescription" : {
+            "text" : "Using a 'delete' statement to delete a local variable is unnecessary, because the variable is deleted automatically when the function exits."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "useless-code" ],
+            "description" : "Using a 'delete' statement to delete a local variable is\n              unnecessary, because the variable is deleted automatically when\n              the function exits.",
+            "id" : "py/unnecessary-delete",
+            "kind" : "problem",
+            "name" : "Unnecessary delete statement in function",
+            "precision" : "high",
+            "problem.severity" : "warning",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/redundant-else",
+          "name" : "py/redundant-else",
+          "shortDescription" : {
+            "text" : "Unnecessary 'else' clause in loop"
+          },
+          "fullDescription" : {
+            "text" : "An 'else' clause in a 'for' or 'while' statement that does not contain a 'break' is redundant."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "useless-code" ],
+            "description" : "An 'else' clause in a 'for' or 'while' statement that does not contain a 'break' is redundant.",
+            "id" : "py/redundant-else",
+            "kind" : "problem",
+            "name" : "Unnecessary 'else' clause in loop",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/unnecessary-pass",
+          "name" : "py/unnecessary-pass",
+          "shortDescription" : {
+            "text" : "Unnecessary pass"
+          },
+          "fullDescription" : {
+            "text" : "Unnecessary 'pass' statement"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "useless-code" ],
+            "description" : "Unnecessary 'pass' statement",
+            "id" : "py/unnecessary-pass",
+            "kind" : "problem",
+            "name" : "Unnecessary pass",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/unreachable-statement",
+          "name" : "py/unreachable-statement",
+          "shortDescription" : {
+            "text" : "Unreachable code"
+          },
+          "fullDescription" : {
+            "text" : "Code is unreachable"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "useless-code", "external/cwe/cwe-561" ],
+            "description" : "Code is unreachable",
+            "id" : "py/unreachable-statement",
+            "kind" : "problem",
+            "name" : "Unreachable code",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/unused-exception-object",
+          "name" : "py/unused-exception-object",
+          "shortDescription" : {
+            "text" : "Unused exception object"
+          },
+          "fullDescription" : {
+            "text" : "An exception object is created, but is not used."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "maintainability" ],
+            "description" : "An exception object is created, but is not used.",
+            "id" : "py/unused-exception-object",
+            "kind" : "problem",
+            "name" : "Unused exception object",
+            "precision" : "very-high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/use-of-exit-or-quit",
+          "name" : "py/use-of-exit-or-quit",
+          "shortDescription" : {
+            "text" : "Use of exit() or quit()"
+          },
+          "fullDescription" : {
+            "text" : "exit() or quit() may fail if the interpreter is run with the -S option."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "maintainability" ],
+            "description" : "exit() or quit() may fail if the interpreter is run with the -S option.",
+            "id" : "py/use-of-exit-or-quit",
+            "kind" : "problem",
+            "name" : "Use of exit() or quit()",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/imprecise-assert",
+          "name" : "py/imprecise-assert",
+          "shortDescription" : {
+            "text" : "Imprecise assert"
+          },
+          "fullDescription" : {
+            "text" : "Using 'assertTrue' or 'assertFalse' rather than a more specific assertion can give uninformative failure messages."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "testability" ],
+            "description" : "Using 'assertTrue' or 'assertFalse' rather than a more specific assertion can give uninformative failure messages.",
+            "id" : "py/imprecise-assert",
+            "kind" : "problem",
+            "name" : "Imprecise assert",
+            "precision" : "very-high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/redundant-global-declaration",
+          "name" : "py/redundant-global-declaration",
+          "shortDescription" : {
+            "text" : "Use of 'global' at module level"
+          },
+          "fullDescription" : {
+            "text" : "Use of the 'global' statement at module level"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "useless-code" ],
+            "description" : "Use of the 'global' statement at module level",
+            "id" : "py/redundant-global-declaration",
+            "kind" : "problem",
+            "name" : "Use of 'global' at module level",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/leaking-list-comprehension",
+          "name" : "py/leaking-list-comprehension",
+          "shortDescription" : {
+            "text" : "List comprehension variable used in enclosing scope"
+          },
+          "fullDescription" : {
+            "text" : "Using the iteration variable of a list comprehension in the enclosing scope will result in different behavior between Python 2 and 3 and is confusing."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "portability", "correctness" ],
+            "description" : "Using the iteration variable of a list comprehension in the enclosing scope will result in different behavior between Python 2 and 3 and is confusing.",
+            "id" : "py/leaking-list-comprehension",
+            "kind" : "problem",
+            "name" : "List comprehension variable used in enclosing scope",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/loop-variable-capture",
+          "name" : "py/loop-variable-capture",
+          "shortDescription" : {
+            "text" : "Loop variable capture"
+          },
+          "fullDescription" : {
+            "text" : "Capture of a loop variable is not the same as capturing the value of a loop variable, and may be erroneous."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "correctness" ],
+            "description" : "Capture of a loop variable is not the same as capturing the value of a loop variable, and may be erroneous.",
+            "id" : "py/loop-variable-capture",
+            "kind" : "problem",
+            "name" : "Loop variable capture",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/multiple-definition",
+          "name" : "py/multiple-definition",
+          "shortDescription" : {
+            "text" : "Variable defined multiple times"
+          },
+          "fullDescription" : {
+            "text" : "Assignment to a variable occurs multiple times without any intermediate use of that variable"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "useless-code", "external/cwe/cwe-563" ],
+            "description" : "Assignment to a variable occurs multiple times without any intermediate use of that variable",
+            "id" : "py/multiple-definition",
+            "kind" : "problem",
+            "name" : "Variable defined multiple times",
+            "precision" : "very-high",
+            "problem.severity" : "warning",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/unused-loop-variable",
+          "name" : "py/unused-loop-variable",
+          "shortDescription" : {
+            "text" : "Suspicious unused loop iteration variable"
+          },
+          "fullDescription" : {
+            "text" : "A loop iteration variable is unused, which suggests an error."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "correctness" ],
+            "description" : "A loop iteration variable is unused, which suggests an error.",
+            "id" : "py/unused-loop-variable",
+            "kind" : "problem",
+            "name" : "Suspicious unused loop iteration variable",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/undefined-export",
+          "name" : "py/undefined-export",
+          "shortDescription" : {
+            "text" : "Explicit export is not defined"
+          },
+          "fullDescription" : {
+            "text" : "Including an undefined attribute in `__all__` causes an exception when the module is imported using '*'"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "maintainability" ],
+            "description" : "Including an undefined attribute in `__all__` causes an exception when\n              the module is imported using '*'",
+            "id" : "py/undefined-export",
+            "kind" : "problem",
+            "name" : "Explicit export is not defined",
+            "precision" : "high",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/unused-local-variable",
+          "name" : "py/unused-local-variable",
+          "shortDescription" : {
+            "text" : "Unused local variable"
+          },
+          "fullDescription" : {
+            "text" : "Local variable is defined but not used"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "maintainability", "useless-code", "external/cwe/cwe-563" ],
+            "description" : "Local variable is defined but not used",
+            "id" : "py/unused-local-variable",
+            "kind" : "problem",
+            "name" : "Unused local variable",
+            "precision" : "very-high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/unused-global-variable",
+          "name" : "py/unused-global-variable",
+          "shortDescription" : {
+            "text" : "Unused global variable"
+          },
+          "fullDescription" : {
+            "text" : "Global variable is defined but not used"
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "note"
+          },
+          "properties" : {
+            "tags" : [ "efficiency", "useless-code", "external/cwe/cwe-563" ],
+            "description" : "Global variable is defined but not used",
+            "id" : "py/unused-global-variable",
+            "kind" : "problem",
+            "name" : "Unused global variable",
+            "precision" : "high",
+            "problem.severity" : "recommendation",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/overwritten-inherited-attribute",
+          "name" : "py/overwritten-inherited-attribute",
+          "shortDescription" : {
+            "text" : "Overwriting attribute in super-class or sub-class"
+          },
+          "fullDescription" : {
+            "text" : "Assignment to self attribute overwrites attribute previously defined in subclass or superclass `__init__` method."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "maintainability", "modularity" ],
+            "description" : "Assignment to self attribute overwrites attribute previously defined in subclass or superclass `__init__` method.",
+            "id" : "py/overwritten-inherited-attribute",
+            "kind" : "problem",
+            "name" : "Overwriting attribute in super-class or sub-class",
+            "precision" : "medium",
+            "problem.severity" : "warning",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/import-of-mutable-attribute",
+          "name" : "py/import-of-mutable-attribute",
+          "shortDescription" : {
+            "text" : "Importing value of mutable attribute"
+          },
+          "fullDescription" : {
+            "text" : "Importing the value of a mutable attribute directly means that changes in global state will not be observed locally."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "maintainability", "modularity" ],
+            "description" : "Importing the value of a mutable attribute directly means that changes in global state will not be observed locally.",
+            "id" : "py/import-of-mutable-attribute",
+            "kind" : "problem",
+            "name" : "Importing value of mutable attribute",
+            "precision" : "medium",
+            "problem.severity" : "warning",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/pythagorean",
+          "name" : "py/pythagorean",
+          "shortDescription" : {
+            "text" : "Pythagorean calculation with sub-optimal numerics"
+          },
+          "fullDescription" : {
+            "text" : "Calculating the length of the hypotenuse using the standard formula may lead to overflow."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "accuracy" ],
+            "description" : "Calculating the length of the hypotenuse using the standard formula may lead to overflow.",
+            "id" : "py/pythagorean",
+            "kind" : "problem",
+            "name" : "Pythagorean calculation with sub-optimal numerics",
+            "precision" : "medium",
+            "problem.severity" : "warning",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/file-not-closed",
+          "name" : "py/file-not-closed",
+          "shortDescription" : {
+            "text" : "File is not always closed"
+          },
+          "fullDescription" : {
+            "text" : "Opening a file without ensuring that it is always closed may cause resource leaks."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "efficiency", "correctness", "resources", "external/cwe/cwe-772" ],
+            "description" : "Opening a file without ensuring that it is always closed may cause resource leaks.",
+            "id" : "py/file-not-closed",
+            "kind" : "problem",
+            "name" : "File is not always closed",
+            "precision" : "medium",
+            "problem.severity" : "warning",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/tarslip",
+          "name" : "py/tarslip",
+          "shortDescription" : {
+            "text" : "Arbitrary file write during tarfile extraction"
+          },
+          "fullDescription" : {
+            "text" : "Extracting files from a malicious tar archive without validating that the destination file path is within the destination directory can cause files outside the destination directory to be overwritten."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-022" ],
+            "description" : "Extracting files from a malicious tar archive without validating that the\n              destination file path is within the destination directory can cause files outside\n              the destination directory to be overwritten.",
+            "id" : "py/tarslip",
+            "kind" : "path-problem",
+            "name" : "Arbitrary file write during tarfile extraction",
+            "precision" : "medium",
+            "problem.severity" : "error",
+            "security-severity" : "7.5"
+          }
+        }, {
+          "id" : "py/jinja2/autoescape-false",
+          "name" : "py/jinja2/autoescape-false",
+          "shortDescription" : {
+            "text" : "Jinja2 templating with autoescape=False"
+          },
+          "fullDescription" : {
+            "text" : "Using jinja2 templates with 'autoescape=False' can cause a cross-site scripting vulnerability."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-079" ],
+            "description" : "Using jinja2 templates with 'autoescape=False' can\n              cause a cross-site scripting vulnerability.",
+            "id" : "py/jinja2/autoescape-false",
+            "kind" : "problem",
+            "name" : "Jinja2 templating with autoescape=False",
+            "precision" : "medium",
+            "problem.severity" : "error",
+            "security-severity" : "6.1"
+          }
+        }, {
+          "id" : "py/log-injection",
+          "name" : "py/log-injection",
+          "shortDescription" : {
+            "text" : "Log Injection"
+          },
+          "fullDescription" : {
+            "text" : "Building log entries from user-controlled data is vulnerable to insertion of forged log entries by a malicious user."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-117" ],
+            "description" : "Building log entries from user-controlled data is vulnerable to\n              insertion of forged log entries by a malicious user.",
+            "id" : "py/log-injection",
+            "kind" : "path-problem",
+            "name" : "Log Injection",
+            "precision" : "medium",
+            "problem.severity" : "error",
+            "security-severity" : "7.8"
+          }
+        }, {
+          "id" : "py/request-without-cert-validation",
+          "name" : "py/request-without-cert-validation",
+          "shortDescription" : {
+            "text" : "Request without certificate validation"
+          },
+          "fullDescription" : {
+            "text" : "Making a request without certificate validation can allow man-in-the-middle attacks."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-295" ],
+            "description" : "Making a request without certificate validation can allow man-in-the-middle attacks.",
+            "id" : "py/request-without-cert-validation",
+            "kind" : "problem",
+            "name" : "Request without certificate validation",
+            "precision" : "medium",
+            "problem.severity" : "error",
+            "security-severity" : "7.5"
+          }
+        }, {
+          "id" : "py/overly-permissive-file",
+          "name" : "py/overly-permissive-file",
+          "shortDescription" : {
+            "text" : "Overly permissive file permissions"
+          },
+          "fullDescription" : {
+            "text" : "Allowing files to be readable or writable by users other than the owner may allow sensitive information to be accessed."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "external/cwe/cwe-732", "security" ],
+            "description" : "Allowing files to be readable or writable by users other than the owner may allow sensitive information to be accessed.",
+            "id" : "py/overly-permissive-file",
+            "kind" : "problem",
+            "name" : "Overly permissive file permissions",
+            "precision" : "medium",
+            "problem.severity" : "warning",
+            "security-severity" : "7.8",
+            "sub-severity" : "high"
+          }
+        }, {
+          "id" : "py/hardcoded-credentials",
+          "name" : "py/hardcoded-credentials",
+          "shortDescription" : {
+            "text" : "Hard-coded credentials"
+          },
+          "fullDescription" : {
+            "text" : "Credentials are hard coded in the source code of the application."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-259", "external/cwe/cwe-321", "external/cwe/cwe-798" ],
+            "description" : "Credentials are hard coded in the source code of the application.",
+            "id" : "py/hardcoded-credentials",
+            "kind" : "path-problem",
+            "name" : "Hard-coded credentials",
+            "precision" : "medium",
+            "problem.severity" : "error",
+            "security-severity" : "9.8"
+          }
+        }, {
+          "id" : "py/partial-ssrf",
+          "name" : "py/partial-ssrf",
+          "shortDescription" : {
+            "text" : "Partial server-side request forgery"
+          },
+          "fullDescription" : {
+            "text" : "Making a network request to a URL that is partially user-controlled allows for request forgery attacks."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "security", "external/cwe/cwe-918" ],
+            "description" : "Making a network request to a URL that is partially user-controlled allows for request forgery attacks.",
+            "id" : "py/partial-ssrf",
+            "kind" : "path-problem",
+            "name" : "Partial server-side request forgery",
+            "precision" : "medium",
+            "problem.severity" : "error",
+            "security-severity" : "9.1"
+          }
+        }, {
+          "id" : "py/exit-from-finally",
+          "name" : "py/exit-from-finally",
+          "shortDescription" : {
+            "text" : "'break' or 'return' statement in finally"
+          },
+          "fullDescription" : {
+            "text" : "Using a Break or Return statement in a finally block causes the Try-finally block to exit, discarding the exception."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "warning"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "maintainability", "external/cwe/cwe-584" ],
+            "description" : "Using a Break or Return statement in a finally block causes the\n              Try-finally block to exit, discarding the exception.",
+            "id" : "py/exit-from-finally",
+            "kind" : "problem",
+            "name" : "'break' or 'return' statement in finally",
+            "precision" : "medium",
+            "problem.severity" : "warning",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/return-or-yield-outside-function",
+          "name" : "py/return-or-yield-outside-function",
+          "shortDescription" : {
+            "text" : "Use of 'return' or 'yield' outside a function"
+          },
+          "fullDescription" : {
+            "text" : "Using 'return' or 'yield' outside a function causes a 'SyntaxError' at runtime."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "Using 'return' or 'yield' outside a function causes a 'SyntaxError' at runtime.",
+            "id" : "py/return-or-yield-outside-function",
+            "kind" : "problem",
+            "name" : "Use of 'return' or 'yield' outside a function",
+            "precision" : "medium",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/undefined-placeholder-variable",
+          "name" : "py/undefined-placeholder-variable",
+          "shortDescription" : {
+            "text" : "Use of an undefined placeholder variable"
+          },
+          "fullDescription" : {
+            "text" : "Using a variable before it is initialized causes an exception."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "Using a variable before it is initialized causes an exception.",
+            "id" : "py/undefined-placeholder-variable",
+            "kind" : "problem",
+            "name" : "Use of an undefined placeholder variable",
+            "precision" : "medium",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/uninitialized-local-variable",
+          "name" : "py/uninitialized-local-variable",
+          "shortDescription" : {
+            "text" : "Potentially uninitialized local variable"
+          },
+          "fullDescription" : {
+            "text" : "Using a local variable before it is initialized causes an UnboundLocalError."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true,
+            "level" : "error"
+          },
+          "properties" : {
+            "tags" : [ "reliability", "correctness" ],
+            "description" : "Using a local variable before it is initialized causes an UnboundLocalError.",
+            "id" : "py/uninitialized-local-variable",
+            "kind" : "problem",
+            "name" : "Potentially uninitialized local variable",
+            "precision" : "medium",
+            "problem.severity" : "error",
+            "sub-severity" : "low"
+          }
+        }, {
+          "id" : "py/summary/lines-of-code",
+          "name" : "py/summary/lines-of-code",
+          "shortDescription" : {
+            "text" : "Total lines of Python code in the database"
+          },
+          "fullDescription" : {
+            "text" : "The total number of lines of Python code across all files, including external libraries and auto-generated files. This is a useful metric of the size of a database. This query counts the lines of code, excluding whitespace or comments."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true
+          },
+          "properties" : {
+            "tags" : [ "summary" ],
+            "description" : "The total number of lines of Python code across all files, including\n   external libraries and auto-generated files. This is a useful metric of the size of a\n   database. This query counts the lines of code, excluding whitespace or comments.",
+            "id" : "py/summary/lines-of-code",
+            "kind" : "metric",
+            "name" : "Total lines of Python code in the database"
+          }
+        }, {
+          "id" : "py/summary/lines-of-user-code",
+          "name" : "py/summary/lines-of-user-code",
+          "shortDescription" : {
+            "text" : "Total lines of user written Python code in the database"
+          },
+          "fullDescription" : {
+            "text" : "The total number of lines of Python code from the source code directory, excluding auto-generated files. This query counts the lines of code, excluding whitespace or comments. Note: If external libraries are included in the codebase either in a checked-in virtual environment or as vendored code, that will currently be counted as user written code."
+          },
+          "defaultConfiguration" : {
+            "enabled" : true
+          },
+          "properties" : {
+            "tags" : [ "summary", "lines-of-code" ],
+            "description" : "The total number of lines of Python code from the source code directory,\n   excluding auto-generated files. This query counts the lines of code, excluding\n   whitespace or comments. Note: If external libraries are included in the codebase\n   either in a checked-in virtual environment or as vendored code, that will currently\n   be counted as user written code.",
+            "id" : "py/summary/lines-of-user-code",
+            "kind" : "metric",
+            "name" : "Total lines of user written Python code in the database"
+          }
+        } ]
+      },
+      "extensions" : [ {
+        "name" : "codeql/go-all",
+        "semanticVersion" : "0.1.3+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/go-all/0.1.3/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/go-all/0.1.3/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/go-examples",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/go-examples/0.0.0/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/go-examples/0.0.0/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/java-all",
+        "semanticVersion" : "0.2.2+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/java-all/0.2.2/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/java-all/0.2.2/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/ruby-queries",
+        "semanticVersion" : "0.1.3+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/ruby-queries/0.1.3/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/ruby-queries/0.1.3/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/csharp-all",
+        "semanticVersion" : "0.2.2+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/csharp-all/0.2.2/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/csharp-all/0.2.2/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/javascript-examples",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/javascript-examples/0.0.0/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/javascript-examples/0.0.0/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/ruby-all",
+        "semanticVersion" : "0.2.2+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/ruby-all/0.2.2/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/ruby-all/0.2.2/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/ruby-examples",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/ruby-examples/0.0.0/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/ruby-examples/0.0.0/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/cpp-queries",
+        "semanticVersion" : "0.1.3+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/cpp-queries/0.1.3/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/cpp-queries/0.1.3/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/java-examples",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/java-examples/0.0.0/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/java-examples/0.0.0/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/python-queries",
+        "semanticVersion" : "0.1.3+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/python-queries/0.1.3/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/python-queries/0.1.3/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/suite-helpers",
+        "semanticVersion" : "0.1.0+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/suite-helpers/0.1.0/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/suite-helpers/0.1.0/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/python-examples",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/python-examples/0.0.0/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/python-examples/0.0.0/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/javascript-queries",
+        "semanticVersion" : "0.1.3+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/javascript-queries/0.1.3/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/javascript-queries/0.1.3/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/go-queries",
+        "semanticVersion" : "0.1.3+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/go-queries/0.1.3/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/go-queries/0.1.3/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/cpp-all",
+        "semanticVersion" : "0.2.2+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/cpp-all/0.2.2/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/cpp-all/0.2.2/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/python-all",
+        "semanticVersion" : "0.4.0+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/python-all/0.4.0/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/python-all/0.4.0/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "legacy-upgrades",
+        "semanticVersion" : "0.0.0",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/legacy-upgrades/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/legacy-upgrades/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/csharp-examples",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/csharp-examples/0.0.0/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/csharp-examples/0.0.0/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/java-queries",
+        "semanticVersion" : "0.1.3+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/java-queries/0.1.3/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/java-queries/0.1.3/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/javascript-all",
+        "semanticVersion" : "0.1.3+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/javascript-all/0.1.3/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/javascript-all/0.1.3/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/csharp-queries",
+        "semanticVersion" : "0.1.3+8cd261af0ed7edb7cd6b8ea6a0ffd99033b79783",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/csharp-queries/0.1.3/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/csharp-queries/0.1.3/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      }, {
+        "name" : "codeql/cpp-examples",
+        "locations" : [ {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/cpp-examples/0.0.0/",
+          "description" : {
+            "text" : "The QL pack root directory."
+          }
+        }, {
+          "uri" : "file:///opt/homebrew/Caskroom/codeql-bundle/2.9.3/codeql/qlpacks/codeql/cpp-examples/0.0.0/qlpack.yml",
+          "description" : {
+            "text" : "The QL pack definition file."
+          }
+        } ]
+      } ]
+    },
+    "invocations" : [ {
+      "toolExecutionNotifications" : [ {
+        "locations" : [ {
+          "physicalLocation" : {
+            "artifactLocation" : {
+              "uri" : "server/models/books.py",
+              "uriBaseId" : "%SRCROOT%",
+              "index" : 4
+            }
+          }
+        } ],
+        "message" : {
+          "text" : ""
+        },
+        "level" : "none",
+        "descriptor" : {
+          "id" : "py/diagnostics/successfully-extracted-files",
+          "index" : 1
+        },
+        "properties" : {
+          "formattedMessage" : {
+            "text" : ""
+          },
+          "relatedLocations" : [ ]
+        }
+      }, {
+        "locations" : [ {
+          "physicalLocation" : {
+            "artifactLocation" : {
+              "uri" : "server/routes.py",
+              "uriBaseId" : "%SRCROOT%",
+              "index" : 2
+            }
+          }
+        } ],
+        "message" : {
+          "text" : ""
+        },
+        "level" : "none",
+        "descriptor" : {
+          "id" : "py/diagnostics/successfully-extracted-files",
+          "index" : 1
+        },
+        "properties" : {
+          "formattedMessage" : {
+            "text" : ""
+          },
+          "relatedLocations" : [ ]
+        }
+      }, {
+        "locations" : [ {
+          "physicalLocation" : {
+            "artifactLocation" : {
+              "uri" : "server/webapp.py",
+              "uriBaseId" : "%SRCROOT%",
+              "index" : 3
+            }
+          }
+        } ],
+        "message" : {
+          "text" : ""
+        },
+        "level" : "none",
+        "descriptor" : {
+          "id" : "py/diagnostics/successfully-extracted-files",
+          "index" : 1
+        },
+        "properties" : {
+          "formattedMessage" : {
+            "text" : ""
+          },
+          "relatedLocations" : [ ]
+        }
+      }, {
+        "locations" : [ {
+          "physicalLocation" : {
+            "artifactLocation" : {
+              "uri" : "server/models/__init__.py",
+              "uriBaseId" : "%SRCROOT%",
+              "index" : 5
+            }
+          }
+        } ],
+        "message" : {
+          "text" : ""
+        },
+        "level" : "none",
+        "descriptor" : {
+          "id" : "py/diagnostics/successfully-extracted-files",
+          "index" : 1
+        },
+        "properties" : {
+          "formattedMessage" : {
+            "text" : ""
+          },
+          "relatedLocations" : [ ]
+        }
+      }, {
+        "locations" : [ {
+          "physicalLocation" : {
+            "artifactLocation" : {
+              "uri" : "server/__main__.py",
+              "uriBaseId" : "%SRCROOT%",
+              "index" : 0
+            }
+          }
+        } ],
+        "message" : {
+          "text" : ""
+        },
+        "level" : "none",
+        "descriptor" : {
+          "id" : "py/diagnostics/successfully-extracted-files",
+          "index" : 1
+        },
+        "properties" : {
+          "formattedMessage" : {
+            "text" : ""
+          },
+          "relatedLocations" : [ ]
+        }
+      }, {
+        "locations" : [ {
+          "physicalLocation" : {
+            "artifactLocation" : {
+              "uri" : "server/__init__.py",
+              "uriBaseId" : "%SRCROOT%",
+              "index" : 6
+            }
+          }
+        } ],
+        "message" : {
+          "text" : ""
+        },
+        "level" : "none",
+        "descriptor" : {
+          "id" : "py/diagnostics/successfully-extracted-files",
+          "index" : 1
+        },
+        "properties" : {
+          "formattedMessage" : {
+            "text" : ""
+          },
+          "relatedLocations" : [ ]
+        }
+      } ],
+      "executionSuccessful" : true
+    } ],
+    "artifacts" : [ {
+      "location" : {
+        "uri" : "server/__main__.py",
+        "uriBaseId" : "%SRCROOT%",
+        "index" : 0
+      }
+    }, {
+      "location" : {
+        "uri" : "file:/Users/felickz/Repos/felickz-advanced-security-python/server/models",
+        "index" : 1
+      }
+    }, {
+      "location" : {
+        "uri" : "server/routes.py",
+        "uriBaseId" : "%SRCROOT%",
+        "index" : 2
+      }
+    }, {
+      "location" : {
+        "uri" : "server/webapp.py",
+        "uriBaseId" : "%SRCROOT%",
+        "index" : 3
+      }
+    }, {
+      "location" : {
+        "uri" : "server/models/books.py",
+        "uriBaseId" : "%SRCROOT%",
+        "index" : 4
+      }
+    }, {
+      "location" : {
+        "uri" : "server/models/__init__.py",
+        "uriBaseId" : "%SRCROOT%",
+        "index" : 5
+      }
+    }, {
+      "location" : {
+        "uri" : "server/__init__.py",
+        "uriBaseId" : "%SRCROOT%",
+        "index" : 6
+      }
+    } ],
+    "results" : [ {
+      "ruleId" : "py/polluting-import",
+      "ruleIndex" : 83,
+      "rule" : {
+        "id" : "py/polluting-import",
+        "index" : 83
+      },
+      "message" : {
+        "text" : "Import pollutes the enclosing namespace, as the imported module [server.models](1) does not define '__all__'."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "server/__main__.py",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
+            "startLine" : 6,
+            "endColumn" : 28
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "7b7b4208f126cb8:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      },
+      "relatedLocations" : [ {
+        "id" : 1,
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "file:/Users/felickz/Repos/felickz-advanced-security-python/server/models",
+            "index" : 1
+          }
+        },
+        "message" : {
+          "text" : "server.models"
+        }
+      } ]
+    }, {
+      "ruleId" : "py/polluting-import",
+      "ruleIndex" : 83,
+      "rule" : {
+        "id" : "py/polluting-import",
+        "index" : 83
+      },
+      "message" : {
+        "text" : "Import pollutes the enclosing namespace, as the imported module [server.routes](1) does not define '__all__'."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "server/__main__.py",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 0
+          },
+          "region" : {
+            "startLine" : 7,
+            "endColumn" : 28
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "1558c1fc3b6a0ac0:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      },
+      "relatedLocations" : [ {
+        "id" : 1,
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "server/routes.py",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 2
+          }
+        },
+        "message" : {
+          "text" : "server.routes"
+        }
+      } ]
+    }, {
+      "ruleId" : "py/unused-import",
+      "ruleIndex" : 84,
+      "rule" : {
+        "id" : "py/unused-import",
+        "index" : 84
+      },
+      "message" : {
+        "text" : "Import of 'make_response' is not used."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "server/routes.py",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 2
+          },
+          "region" : {
+            "startLine" : 2,
+            "endColumn" : 58
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "ebd3edce385f8c43:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    }, {
+      "ruleId" : "py/sql-injection",
+      "ruleIndex" : 93,
+      "rule" : {
+        "id" : "py/sql-injection",
+        "index" : 93
+      },
+      "message" : {
+        "text" : "This SQL query depends on [a user-provided value](1)."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "server/routes.py",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 2
+          },
+          "region" : {
+            "startLine" : 16,
+            "startColumn" : 13,
+            "endColumn" : 67
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "a452eeb604f1a3e6:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      },
+      "codeFlows" : [ {
+        "threadFlows" : [ {
+          "locations" : [ {
+            "location" : {
+              "physicalLocation" : {
+                "artifactLocation" : {
+                  "uri" : "server/routes.py",
+                  "uriBaseId" : "%SRCROOT%",
+                  "index" : 2
+                },
+                "region" : {
+                  "startLine" : 10,
+                  "startColumn" : 12,
+                  "endColumn" : 19
+                }
+              },
+              "message" : {
+                "text" : "ControlFlowNode for request"
+              }
+            }
+          }, {
+            "location" : {
+              "physicalLocation" : {
+                "artifactLocation" : {
+                  "uri" : "server/routes.py",
+                  "uriBaseId" : "%SRCROOT%",
+                  "index" : 2
+                },
+                "region" : {
+                  "startLine" : 10,
+                  "startColumn" : 12,
+                  "endColumn" : 24
+                }
+              },
+              "message" : {
+                "text" : "ControlFlowNode for Attribute"
+              }
+            }
+          }, {
+            "location" : {
+              "physicalLocation" : {
+                "artifactLocation" : {
+                  "uri" : "server/routes.py",
+                  "uriBaseId" : "%SRCROOT%",
+                  "index" : 2
+                },
+                "region" : {
+                  "startLine" : 16,
+                  "startColumn" : 13,
+                  "endColumn" : 67
+                }
+              },
+              "message" : {
+                "text" : "ControlFlowNode for BinaryExpr"
+              }
+            }
+          } ]
+        } ]
+      } ],
+      "relatedLocations" : [ {
+        "id" : 1,
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "server/routes.py",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 2
+          },
+          "region" : {
+            "startLine" : 10,
+            "startColumn" : 12,
+            "endColumn" : 19
+          }
+        },
+        "message" : {
+          "text" : "a user-provided value"
+        }
+      } ]
+    }, {
+      "ruleId" : "py/sql-injection",
+      "ruleIndex" : 93,
+      "rule" : {
+        "id" : "py/sql-injection",
+        "index" : 93
+      },
+      "message" : {
+        "text" : "This SQL query depends on [a user-provided value](1).\nThis SQL query depends on [a user-provided value](2)."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "server/routes.py",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 2
+          },
+          "region" : {
+            "startLine" : 22,
+            "startColumn" : 13,
+            "endColumn" : 71
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "cc94dfaf0d882215:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      },
+      "codeFlows" : [ {
+        "threadFlows" : [ {
+          "locations" : [ {
+            "location" : {
+              "physicalLocation" : {
+                "artifactLocation" : {
+                  "uri" : "server/routes.py",
+                  "uriBaseId" : "%SRCROOT%",
+                  "index" : 2
+                },
+                "region" : {
+                  "startLine" : 10,
+                  "startColumn" : 12,
+                  "endColumn" : 19
+                }
+              },
+              "message" : {
+                "text" : "ControlFlowNode for request"
+              }
+            }
+          }, {
+            "location" : {
+              "physicalLocation" : {
+                "artifactLocation" : {
+                  "uri" : "server/routes.py",
+                  "uriBaseId" : "%SRCROOT%",
+                  "index" : 2
+                },
+                "region" : {
+                  "startLine" : 11,
+                  "startColumn" : 14,
+                  "endColumn" : 26
+                }
+              },
+              "message" : {
+                "text" : "ControlFlowNode for Attribute"
+              }
+            }
+          }, {
+            "location" : {
+              "physicalLocation" : {
+                "artifactLocation" : {
+                  "uri" : "server/routes.py",
+                  "uriBaseId" : "%SRCROOT%",
+                  "index" : 2
+                },
+                "region" : {
+                  "startLine" : 22,
+                  "startColumn" : 13,
+                  "endColumn" : 71
+                }
+              },
+              "message" : {
+                "text" : "ControlFlowNode for BinaryExpr"
+              }
+            }
+          } ]
+        } ]
+      }, {
+        "threadFlows" : [ {
+          "locations" : [ {
+            "location" : {
+              "physicalLocation" : {
+                "artifactLocation" : {
+                  "uri" : "server/routes.py",
+                  "uriBaseId" : "%SRCROOT%",
+                  "index" : 2
+                },
+                "region" : {
+                  "startLine" : 11,
+                  "startColumn" : 14,
+                  "endColumn" : 21
+                }
+              },
+              "message" : {
+                "text" : "ControlFlowNode for request"
+              }
+            }
+          }, {
+            "location" : {
+              "physicalLocation" : {
+                "artifactLocation" : {
+                  "uri" : "server/routes.py",
+                  "uriBaseId" : "%SRCROOT%",
+                  "index" : 2
+                },
+                "region" : {
+                  "startLine" : 11,
+                  "startColumn" : 14,
+                  "endColumn" : 26
+                }
+              },
+              "message" : {
+                "text" : "ControlFlowNode for Attribute"
+              }
+            }
+          }, {
+            "location" : {
+              "physicalLocation" : {
+                "artifactLocation" : {
+                  "uri" : "server/routes.py",
+                  "uriBaseId" : "%SRCROOT%",
+                  "index" : 2
+                },
+                "region" : {
+                  "startLine" : 22,
+                  "startColumn" : 13,
+                  "endColumn" : 71
+                }
+              },
+              "message" : {
+                "text" : "ControlFlowNode for BinaryExpr"
+              }
+            }
+          } ]
+        } ]
+      } ],
+      "relatedLocations" : [ {
+        "id" : 1,
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "server/routes.py",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 2
+          },
+          "region" : {
+            "startLine" : 10,
+            "startColumn" : 12,
+            "endColumn" : 19
+          }
+        },
+        "message" : {
+          "text" : "a user-provided value"
+        }
+      }, {
+        "id" : 2,
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "server/routes.py",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 2
+          },
+          "region" : {
+            "startLine" : 11,
+            "startColumn" : 14,
+            "endColumn" : 21
+          }
+        },
+        "message" : {
+          "text" : "a user-provided value"
+        }
+      } ]
+    }, {
+      "ruleId" : "py/unused-local-variable",
+      "ruleIndex" : 145,
+      "rule" : {
+        "id" : "py/unused-local-variable",
+        "index" : 145
+      },
+      "message" : {
+        "text" : "The value assigned to local variable 'read' is never used."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "server/routes.py",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 2
+          },
+          "region" : {
+            "startLine" : 12,
+            "startColumn" : 5,
+            "endColumn" : 9
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "261cd04417ec4974:1",
+        "primaryLocationStartColumnFingerprint" : "0"
+      }
+    }, {
+      "ruleId" : "py/hardcoded-credentials",
+      "ruleIndex" : 156,
+      "rule" : {
+        "id" : "py/hardcoded-credentials",
+        "index" : 156
+      },
+      "message" : {
+        "text" : "Use of [hardcoded credentials](1)."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "server/webapp.py",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 3
+          },
+          "region" : {
+            "startLine" : 29,
+            "startColumn" : 18,
+            "endColumn" : 26
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "45e127f837fa937d:1",
+        "primaryLocationStartColumnFingerprint" : "9"
+      },
+      "codeFlows" : [ {
+        "threadFlows" : [ {
+          "locations" : [ {
+            "location" : {
+              "physicalLocation" : {
+                "artifactLocation" : {
+                  "uri" : "server/webapp.py",
+                  "uriBaseId" : "%SRCROOT%",
+                  "index" : 3
+                },
+                "region" : {
+                  "startLine" : 20,
+                  "startColumn" : 12,
+                  "endColumn" : 25
+                }
+              },
+              "message" : {
+                "text" : "hard coded value"
+              }
+            }
+          }, {
+            "location" : {
+              "physicalLocation" : {
+                "artifactLocation" : {
+                  "uri" : "server/webapp.py",
+                  "uriBaseId" : "%SRCROOT%",
+                  "index" : 3
+                },
+                "region" : {
+                  "startLine" : 29,
+                  "startColumn" : 18,
+                  "endColumn" : 26
+                }
+              },
+              "message" : {
+                "text" : "hard coded value"
+              }
+            }
+          } ]
+        } ]
+      } ],
+      "relatedLocations" : [ {
+        "id" : 1,
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "server/webapp.py",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 3
+          },
+          "region" : {
+            "startLine" : 20,
+            "startColumn" : 12,
+            "endColumn" : 25
+          }
+        },
+        "message" : {
+          "text" : "hardcoded credentials"
+        }
+      } ]
+    }, {
+      "ruleId" : "py/hardcoded-credentials",
+      "ruleIndex" : 156,
+      "rule" : {
+        "id" : "py/hardcoded-credentials",
+        "index" : 156
+      },
+      "message" : {
+        "text" : "Use of [hardcoded credentials](1)."
+      },
+      "locations" : [ {
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "server/webapp.py",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 3
+          },
+          "region" : {
+            "startLine" : 30,
+            "startColumn" : 18,
+            "endColumn" : 26
+          }
+        }
+      } ],
+      "partialFingerprints" : {
+        "primaryLocationLineHash" : "920c1d332e19fc16:1",
+        "primaryLocationStartColumnFingerprint" : "9"
+      },
+      "codeFlows" : [ {
+        "threadFlows" : [ {
+          "locations" : [ {
+            "location" : {
+              "physicalLocation" : {
+                "artifactLocation" : {
+                  "uri" : "server/webapp.py",
+                  "uriBaseId" : "%SRCROOT%",
+                  "index" : 3
+                },
+                "region" : {
+                  "startLine" : 21,
+                  "startColumn" : 12,
+                  "endColumn" : 26
+                }
+              },
+              "message" : {
+                "text" : "hard coded value"
+              }
+            }
+          }, {
+            "location" : {
+              "physicalLocation" : {
+                "artifactLocation" : {
+                  "uri" : "server/webapp.py",
+                  "uriBaseId" : "%SRCROOT%",
+                  "index" : 3
+                },
+                "region" : {
+                  "startLine" : 30,
+                  "startColumn" : 18,
+                  "endColumn" : 26
+                }
+              },
+              "message" : {
+                "text" : "hard coded value"
+              }
+            }
+          } ]
+        } ]
+      } ],
+      "relatedLocations" : [ {
+        "id" : 1,
+        "physicalLocation" : {
+          "artifactLocation" : {
+            "uri" : "server/webapp.py",
+            "uriBaseId" : "%SRCROOT%",
+            "index" : 3
+          },
+          "region" : {
+            "startLine" : 21,
+            "startColumn" : 12,
+            "endColumn" : 26
+          }
+        },
+        "message" : {
+          "text" : "hardcoded credentials"
+        }
+      } ]
+    } ],
+    "automationDetails" : {
+      "id" : ".github/workflows/codeql-analysis.yml:analyze/language:python/"
+    },
+    "columnKind" : "unicodeCodePoints",
+    "properties" : {
+      "metricResults" : [ {
+        "rule" : {
+          "id" : "py/summary/lines-of-code",
+          "index" : 162
+        },
+        "ruleId" : "py/summary/lines-of-code",
+        "ruleIndex" : 162,
+        "value" : 96570
+      }, {
+        "rule" : {
+          "id" : "py/summary/lines-of-user-code",
+          "index" : 163
+        },
+        "ruleId" : "py/summary/lines-of-user-code",
+        "ruleIndex" : 163,
+        "value" : 78,
+        "baseline" : 78
+      } ],
+      "semmle.formatSpecifier" : "sarif-latest"
+    }
+  } ]
+}

--- a/server/webapp.py
+++ b/server/webapp.py
@@ -14,3 +14,20 @@ database_uri = os.environ.get('SQLITE_URI', ':memory:')
 
 database = sqlite3.connect(database_uri, check_same_thread=False)
 cursor = database.cursor()
+
+HOST = "acme-trading.com"
+PORT = 8000
+USERNAME = "road_runner"
+PASSWORD = "insecure_pwd"
+
+
+def sell(client, units):
+
+    conn = client.connect(
+        host=HOST,
+        port=PORT,
+        username=USERNAME,
+        password=PASSWORD)
+
+    conn.cmd("sell", 1000)
+    conn.close()

--- a/src/main/java/com/mycompany/app/App.java
+++ b/src/main/java/com/mycompany/app/App.java
@@ -1,0 +1,13 @@
+package com.mycompany.app;
+
+/**
+ * Hello world!
+ *
+ */
+public class App 
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Hello World!" );
+    }
+}

--- a/src/test/java/com/mycompany/app/AppTest.java
+++ b/src/test/java/com/mycompany/app/AppTest.java
@@ -1,0 +1,20 @@
+package com.mycompany.app;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest 
+{
+    /**
+     * Rigorous Test :-)
+     */
+    @Test
+    public void shouldAnswerWithTrue()
+    {
+        assertTrue( true );
+    }
+}


### PR DESCRIPTION
Create a [codeql config to pull in security-and-quality](https://github.com/octodemo/felickz-advanced-security-python/blob/c323e08b1914e95361fce1a3ce10a27d30d4fc40/.github/codeql/codeql-config.yml)

Verified my change in VSCode CodeQL
> codeql database create pythondb --language=python --overwrite 

![image](https://user-images.githubusercontent.com/1760475/190522079-9179267d-641d-48e3-8839-d61806a65c55.png)

This requires `security-extended` as the[ query is flagged with ](https://github.com/github/codeql/blob/f648dd4a2e5b819016500e2fbe00614091d9c535/python/ql/src/Security/CWE-798/HardcodedCredentials.ql#L7)
>* @precision medium

2 alerts found
- [USERNAME hardcoded](https://github.com/octodemo/felickz-advanced-security-python/security/code-scanning/3)
- [PASSWORD hardcoded](https://github.com/octodemo/felickz-advanced-security-python/security/code-scanning/4)

![image](https://user-images.githubusercontent.com/1760475/190522664-ea1f2ae9-229c-4bc2-b5e5-96aae1f758a2.png)


Ran via [CLI](https://github.com/octodemo/felickz-advanced-security-python/blob/c323e08b1914e95361fce1a3ce10a27d30d4fc40/README.md#cli-commands) and SARIF output remains the same

![image](https://user-images.githubusercontent.com/1760475/190681155-14611b41-bde2-47a9-95f5-765957a030ff.png)

# 10/20 update 
A few additional details on the repro
- using 2.7.1
   - logs showing only 27 queries running - this confirms that security-extended is not being picked up properly ... should be 32 for `security-extended` or 100+ for `security-and-quality`
- config file has a language filter, but this is not used.  Adding in multi lang to the workflow and CLI but no impact to results
```yml
languages: java,python
```
Cannot reproduce in actions
 - using [2.7.1 cli bundle ](https://github.com/octodemo/felickz-advanced-security-python/pull/3/files#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188R47)
 - added [language filter](https://github.com/octodemo/felickz-advanced-security-python/pull/3/files#diff-3c168dbb160e6a97e58e9babfc08dcd60f89cf2c81ff592398940c29e576b870R8)
 - using CLI with `--db-cluster --language=java,python`